### PR TITLE
docs(README): improve with prerequisites, expanded usage, and install methods (#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,104 @@
 # jj-spice
 
-Forge integration for [jj (Jujutsu)](https://github.com/jj-vcs/jj). Manage
-stacked change requests from the command line.
+`jj-spice` manages stacked change requests in a [jj (Jujutsu)](https://github.com/jj-vcs/jj) repository.
+
+Stacked change requests break a large change into a chain of small, reviewable
+PRs that depend on each other. `jj-spice` automates the tedious parts — creating
+the PRs, keeping their base branches in sync, and tracking their status.
+
+`jj-spice` allows you to:
+- Submit a stack of change requests
+- Sync the current stack with a remote repository
+- Visualize the stack and its review status
+
+The following version control systems are supported:
+- [GitHub](https://github.com)
+
+## Demo
+
+[![asciicast](https://asciinema.org/a/kBv6aeMHxa0KaMt3.svg)](https://asciinema.org/a/kBv6aeMHxa0KaMt3)
+
+## Prerequisites
+
+- [GitHub CLI (`gh`)](https://cli.github.com) — required if your repository is hosted on GitHub. Must be authenticated (`gh auth login`)
+
+## Installation
+
+### Homebrew (macOS)
+
+```bash
+brew install alejoborbo/tap/jj-spice
+```
+
+### Scoop (Windows)
+
+```powershell
+scoop install alejoborbo_scoop-bucket/jj-spice
+```
+
+### Winget (Windows)
+
+```powershell
+winget install alejoborbo.jj-spice
+```
+
+### Cargo
+
+```bash
+cargo install jj-spice-cli
+```
+
+### From source
+
+```bash
+git clone https://github.com/alejoborbo/jj-spice.git
+cd jj-spice
+cargo install --path cli
+```
+
+### Direct download
+
+Pre-built binaries for Linux, macOS, and Windows are available on the
+[GitHub Releases](https://github.com/alejoborbo/jj-spice/releases) page.
+
+## Usage
+
+### `jj-spice stack log`
+
+Visualize the bookmark DAG with the status of each change request.
+
+```bash
+# Show the full stack
+jj-spice stack log
+
+# Filter to a specific revset
+jj-spice stack log -r 'trunk()..@'
+```
+
+### `jj-spice stack submit`
+
+Create or update change requests for every bookmark in the stack. Prompts
+interactively for the title, description, and draft status of new PRs.
+
+```bash
+jj-spice stack submit
+```
+
+### `jj-spice stack sync`
+
+Discover existing change requests on the remote and start tracking them locally.
+
+```bash
+# Sync untracked bookmarks
+jj-spice stack sync
+
+# Re-sync already-tracked bookmarks
+jj-spice stack sync --force
+```
 
 ## Shell completion
 
-jj-spice supports two completion methods: **dynamic** (recommended) and
+`jj-spice` supports two completion methods: **dynamic** (recommended) and
 **static**.
 
 Dynamic completion calls back into `jj-spice` at TAB-time, so completions
@@ -13,7 +106,8 @@ stay in sync with the installed version and can complete config keys and
 values. Static completion generates a one-time script that only knows about
 subcommands and flags.
 
-### Dynamic completion (recommended)
+<details>
+<summary><strong>Dynamic completion (recommended)</strong></summary>
 
 Add one of the following to your shell startup file:
 
@@ -47,7 +141,10 @@ eval (COMPLETE=elvish jj-spice | slurp)
 COMPLETE=powershell jj-spice | Out-String | Invoke-Expression
 ```
 
-### Static completion
+</details>
+
+<details>
+<summary><strong>Static completion</strong></summary>
 
 Generate a static script with `jj-spice util completion <SHELL>`. This is
 useful when dynamic completion is not available (e.g. Nushell) or when you
@@ -89,3 +186,9 @@ jj-spice util completion power-shell | Out-String | Invoke-Expression
 ```elvish
 eval (jj-spice util completion elvish | slurp)
 ```
+
+</details>
+
+## License
+
+Licensed under Apache 2.0 — see [LICENSE](LICENSE).


### PR DESCRIPTION
Add stacked CRs explainer, prerequisites (jj + gh), additional install methods (Winget, Cargo, from source, direct download), per-command usage docs, demo asciicast, collapsible shell completions, and license footer.

Tracked issue: #6 