### PR TITLE
feat: add cross-repo PR support via fork-aware Forge trait

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -56,11 +56,7 @@ pub(crate) fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                         .map_err(|e| format!("failed to resolve @: {e}"))?;
                     rt.block_on(async {
                         let detection = detect_forges(env.repo.store(), env.config())?;
-                        let forge = detection
-                            .forges
-                            .into_values()
-                            .next()
-                            .ok_or("no forge detected — is a git remote configured?")?;
+
                         let trunk_name = env
                             .repo
                             .view()
@@ -68,9 +64,13 @@ pub(crate) fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                             .find(|(_, target)| target.local_target.as_normal() == Some(&trunk))
                             .map(|(name, _)| name.as_str().to_string())
                             .ok_or("no bookmark found at trunk commit")?;
+
+                        let (forge, source_repo) = env.resolve_forge(detection.forges)?;
+
                         stack_submit::run(
                             &env,
                             forge.as_ref(),
+                            source_repo.as_deref(),
                             &env.store,
                             &trunk,
                             &head,

--- a/cli/src/commands/env.rs
+++ b/cli/src/commands/env.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use jj_cli::cli_util::{GlobalArgs, RevisionArg, find_workspace_dir};
@@ -13,7 +14,7 @@ use jj_lib::git::GitSettings;
 use jj_lib::id_prefix::IdPrefixContext;
 use jj_lib::op_walk;
 use jj_lib::ref_name::RemoteNameBuf;
-use jj_lib::repo::{ReadonlyRepo, StoreFactories};
+use jj_lib::repo::{ReadonlyRepo, Repo as _, StoreFactories};
 use jj_lib::repo_path::RepoPathUiConverter;
 use jj_lib::revset::{
     ResolvedRevsetExpression, RevsetAliasesMap, RevsetDiagnostics, RevsetExtensions,
@@ -21,6 +22,12 @@ use jj_lib::revset::{
 };
 use jj_lib::settings::UserSettings;
 use jj_lib::workspace::{Workspace, default_working_copy_factories};
+
+use jj_spice_lib::forge::Forge;
+
+/// Resolved forge for PR creation, with an optional source repository
+/// identifier for cross-repo (fork) head refs.
+pub(crate) type ResolvedForge = (Box<dyn Forge>, Option<String>);
 
 use jj_spice_lib::store::SpiceStore;
 
@@ -136,6 +143,99 @@ impl SpiceEnv {
             .get::<String>(["git", "push"])
             .unwrap_or_else(|_| "origin".to_string());
         RemoteNameBuf::from(name)
+    }
+
+    /// Resolve the upstream remote for PR creation in fork mode.
+    ///
+    /// Priority:
+    /// 1. `spice.upstream-remote` config (explicit override).
+    /// 2. `"upstream"` if a remote with that name exists in the git repo.
+    /// 3. `None` — single-remote mode, push remote is also the PR target.
+    pub(crate) fn get_upstream_remote(&self) -> Option<RemoteNameBuf> {
+        // 1. Explicit config override.
+        if let Ok(name) = self.config().get::<String>(["spice", "upstream-remote"])
+            && !name.is_empty()
+        {
+            return Some(RemoteNameBuf::from(name));
+        }
+        // 2. Fall back to "upstream" if that remote exists.
+        let git_repo = jj_lib::git::get_git_repo(self.repo.store()).ok()?;
+        // Check if any remote is named "upstream" by iterating all remote names.
+        let has_upstream = git_repo
+            .remote_names()
+            .iter()
+            .any(|n| n.as_ref() == b"upstream");
+        if has_upstream {
+            return Some(RemoteNameBuf::from("upstream"));
+        }
+        None
+    }
+
+    /// Whether a git remote with the given name is configured in this repo.
+    fn remote_exists(&self, remote: &RemoteNameBuf) -> bool {
+        let Ok(git_repo) = jj_lib::git::get_git_repo(self.repo.store()) else {
+            return false;
+        };
+        git_repo
+            .remote_names()
+            .iter()
+            .any(|n| n.as_ref() == remote.as_str().as_bytes())
+    }
+
+    /// Whether fork mode is active.
+    ///
+    /// Fork mode requires **two distinct remotes** that both exist: the push
+    /// remote (the fork, defaulting to `"origin"`) and the upstream remote
+    /// (where PRs are created). Returns `false` when only one remote is
+    /// configured — even if it happens to be named `"upstream"` — because
+    /// there is no fork relationship to express.
+    ///
+    /// When `true`, branches are pushed to the push remote while change
+    /// requests are created against the upstream remote.
+    pub(crate) fn is_fork_mode(&self) -> bool {
+        let Some(upstream) = self.get_upstream_remote() else {
+            return false;
+        };
+        let push = self.get_default_remote();
+        // The two remotes must be distinct, and the push remote must actually
+        // exist (it may only be a config default like "origin").
+        upstream != push && self.remote_exists(&push)
+    }
+
+    /// Resolve the forge and optional source repository for PR creation.
+    ///
+    /// In **fork mode** (two distinct remotes), PRs target the upstream forge
+    /// while branches are pushed to the fork (push remote). The fork's
+    /// `repo_id` is returned as `source_repo` so the forge can format
+    /// cross-repo head refs (e.g. `"fork-owner:branch"`).
+    ///
+    /// In **single-remote mode**, the only detected forge is used directly
+    /// and `source_repo` is `None`.
+    pub(crate) fn resolve_forge(
+        &self,
+        mut forges: HashMap<String, Box<dyn Forge>>,
+    ) -> Result<ResolvedForge, Box<dyn std::error::Error>> {
+        if self.is_fork_mode() {
+            let upstream_remote = self.get_upstream_remote().unwrap();
+            let push_remote = self.get_default_remote();
+
+            let fork_repo_id = forges.get(push_remote.as_str()).map(|f| f.repo_id());
+            let upstream_forge = forges.remove(upstream_remote.as_str()).ok_or_else(|| {
+                format!(
+                    "upstream remote `{}` has no \
+                         detected forge — check your git remotes",
+                    upstream_remote.as_str()
+                )
+            })?;
+
+            Ok((upstream_forge, fork_repo_id))
+        } else {
+            let forge = forges
+                .into_values()
+                .next()
+                .ok_or("no forge detected — is a git remote configured?")?;
+            Ok((forge, None))
+        }
     }
 
     /// Resolve a revset expression to exactly one commit ID.

--- a/cli/src/commands/stack_log.rs
+++ b/cli/src/commands/stack_log.rs
@@ -77,11 +77,11 @@ pub async fn run(
     let cr_state = load_change_requests(env);
 
     // Detect forges (read-only, no prompting for unmatched remotes).
-    let forge_map = detect_forge_map(env);
+    let detection = detect_forge_result(env);
 
     // Collect nodes and fetch live CR data.
     let nodes: Vec<&BookmarkNode> = graph.iter_graph()?.collect();
-    let live_crs = fetch_live_crs(&nodes, &cr_state, &forge_map).await;
+    let live_crs = fetch_live_crs(&nodes, &cr_state, &detection).await;
 
     // Render the graph.
     render_graph(
@@ -119,11 +119,12 @@ fn load_change_requests(env: &SpiceEnv) -> jj_spice_lib::protos::change_request:
         .unwrap_or_default()
 }
 
-/// Build a forge map from auto-detected forges only (no interactive prompts).
-fn detect_forge_map(env: &SpiceEnv) -> HashMap<String, Box<dyn Forge>> {
-    detect_forges(env.repo.store(), env.config())
-        .map(|DetectionResult { forges, .. }| forges)
-        .unwrap_or_default()
+/// Auto-detect forges from git remotes (no interactive prompts).
+fn detect_forge_result(env: &SpiceEnv) -> DetectionResult {
+    detect_forges(env.repo.store(), env.config()).unwrap_or(DetectionResult {
+        forges: HashMap::new(),
+        unmatched: Vec::new(),
+    })
 }
 
 /// Fetch live change request data for each bookmark that has stored metadata.
@@ -133,7 +134,7 @@ fn detect_forge_map(env: &SpiceEnv) -> HashMap<String, Box<dyn Forge>> {
 async fn fetch_live_crs(
     nodes: &[&BookmarkNode<'_>],
     cr_state: &jj_spice_lib::protos::change_request::ChangeRequests,
-    forge_map: &HashMap<String, Box<dyn Forge>>,
+    detection: &DetectionResult,
 ) -> HashMap<String, Result<Box<dyn ChangeRequest>, String>> {
     let mut results = HashMap::new();
 
@@ -151,12 +152,15 @@ async fn fetch_live_crs(
             None => continue,
         };
 
-        let forge = match find_forge_for_bookmark(node, forge_map) {
-            Some(f) => f,
-            None => {
-                results.insert(name.to_string(), Err("no forge detected".to_string()));
-                continue;
-            }
+        // For cross-repo (fork) PRs the CR lives on the upstream repo,
+        // not the fork the bookmark is tracked on. Try matching by
+        // target_repo first, then fall back to the tracked remote.
+        let forge = detection
+            .resolve_forge_for_meta(meta)
+            .or_else(|| find_forge_for_bookmark(node, &detection.forges));
+        let Some(forge) = forge else {
+            results.insert(name.to_string(), Err("no forge detected".to_string()));
+            continue;
         };
 
         let key = forge as *const dyn Forge;

--- a/cli/src/commands/stack_submit.rs
+++ b/cli/src/commands/stack_submit.rs
@@ -18,9 +18,14 @@ use jj_spice_lib::store::change_request::ChangeRequestStore;
 use crate::commands::env::SpiceEnv;
 
 /// Create change requests for each bookmark in the current stack (trunk..@).
+///
+/// `source_repo` identifies the fork repository for cross-repo PRs; it is
+/// `None` in single-remote mode. See [`CreateParams::source_repo`] for the
+/// forge-specific format.
 pub async fn run(
     env: &SpiceEnv,
     forge: &dyn Forge,
+    source_repo: Option<&str>,
     store: &SpiceStore,
     trunk: &CommitId,
     head: &CommitId,
@@ -40,7 +45,9 @@ pub async fn run(
         check_untracked_changes(&env.ui, env, bookmark)?;
 
         // If the change request already exists, retarget if needed.
-        let existing = get_existing_change_request(&env.ui, &state, forge, bookmark.name()).await?;
+        let existing =
+            get_existing_change_request(&env.ui, &state, forge, bookmark.name(), source_repo)
+                .await?;
 
         let base_bookmark = match ascendants.len() {
             0 => trunk_name,
@@ -105,6 +112,7 @@ pub async fn run(
             title: &title,
             body: Some(&description),
             is_draft,
+            source_repo,
         };
 
         let cr = forge.create(params).await?;
@@ -216,11 +224,15 @@ fn check_untracked_changes(
 /// 1. Check local state first — if already tracked, return it.
 /// 2. Query the forge for CRs matching source/target branches.
 /// 3. If multiple CRs are found, prompt the user to pick one.
+///
+/// `source_repo` is forwarded to [`Forge::find_change_requests`] for
+/// cross-repo PR discovery; pass `None` in single-remote mode.
 async fn get_existing_change_request(
     ui: &jj_cli::ui::Ui,
     state: &ChangeRequests,
     forge: &dyn Forge,
     bookmark: &str,
+    source_repo: Option<&str>,
 ) -> Result<Option<ForgeMeta>, Box<dyn std::error::Error>> {
     // Check local state first.
     if let Some(meta) = state.get(bookmark) {
@@ -228,7 +240,7 @@ async fn get_existing_change_request(
     }
 
     // Query the forge.
-    let metas = forge.find_change_requests(bookmark).await?;
+    let metas = forge.find_change_requests(bookmark, source_repo).await?;
 
     match metas.len() {
         0 => Ok(None),

--- a/cli/src/commands/stack_sync.rs
+++ b/cli/src/commands/stack_sync.rs
@@ -216,19 +216,51 @@ async fn sync_bookmark(
         return Err(BookmarkSyncError::NoTrackedRemotes);
     }
 
-    // Collect all CRs across all tracked remotes.
+    // Collect CRs across all forges reachable from tracked remotes, plus
+    // any other forge in the map that may host cross-repo (fork) PRs.
+    // This ensures PRs opened against an upstream repo are discovered even
+    // when the bookmark is only tracked on the fork remote.
     let mut all_crs: Vec<ForgeMeta> = Vec::new();
+    let mut queried_repos: HashSet<String> = HashSet::new();
 
+    // 1. Query forges matching tracked remotes (primary lookup).
+    //    Also collect their repo_ids — these are the potential fork
+    //    identities used to search for cross-repo PRs in step 2.
     let mut found_forge = false;
+    let mut tracked_repo_ids: Vec<String> = Vec::new();
     for remote_name in &tracked_remotes {
         let forge_instance = match forge_map.get(*remote_name) {
             Some(f) => f,
             None => continue,
         };
         found_forge = true;
+        let repo_id = forge_instance.repo_id();
+        queried_repos.insert(repo_id.clone());
+        tracked_repo_ids.push(repo_id);
 
-        let crs = forge_instance.find_change_requests(bookmark.name()).await?;
+        let crs = forge_instance
+            .find_change_requests(bookmark.name(), None)
+            .await?;
         all_crs.extend(crs);
+    }
+
+    // 2. Query remaining forges that weren't reached via tracked remotes.
+    //    For each, try with every tracked forge as a potential source (fork)
+    //    so cross-repo PRs are found via the correct head filter
+    //    (e.g. "fork-owner:branch" instead of "upstream-owner:branch").
+    for forge_instance in forge_map.values() {
+        if queried_repos.contains(&forge_instance.repo_id()) {
+            continue;
+        }
+        for source_id in &tracked_repo_ids {
+            let crs = forge_instance
+                .find_change_requests(bookmark.name(), Some(source_id))
+                .await?;
+            if !crs.is_empty() {
+                found_forge = true;
+                all_crs.extend(crs);
+            }
+        }
     }
 
     if !found_forge {

--- a/lib/src/forge.rs
+++ b/lib/src/forge.rs
@@ -76,6 +76,13 @@ pub struct CreateParams<'a> {
     pub body: Option<&'a str>,
     /// Whether to create the change request as a draft.
     pub is_draft: bool,
+    /// Identity of the repository where the source branch lives, for
+    /// cross-repo (fork-to-upstream) change requests.
+    ///
+    /// When `None`, the source is assumed to be the same repository as the
+    /// target (no fork). When `Some`, the value is the fork's
+    /// [`Forge::repo_id`].
+    pub source_repo: Option<&'a str>,
 }
 
 /// Object-safe forge backend interface.
@@ -86,18 +93,20 @@ pub struct CreateParams<'a> {
 /// Methods return boxed futures to ensure dyn-compatibility. Implementations
 /// use `Box::pin(async move { ... })` to build the future.
 pub trait Forge: Send + Sync {
+    /// Opaque identity string for this forge's repository.
+    ///
+    /// Used to match a forge instance against the `target_repo` stored in
+    /// [`ForgeMeta`] when routing cross-repo (fork) operations to the correct
+    /// forge instance. The format is forge-specific and must not be parsed
+    /// by callers.
+    fn repo_id(&self) -> String;
+
     /// Create a new change request on the forge.
     fn create<'a>(&'a self, params: CreateParams<'a>) -> BoxFuture<'a, ForgeResult>;
 
     /// Fetch a change request by its stored metadata.
     fn get<'a>(&'a self, meta: &'a ForgeMeta) -> BoxFuture<'a, ForgeResult>;
 
-    /// Fetch multiple change requests in a single operation.
-    ///
-    /// Forges that support batching (e.g. GitHub via GraphQL) override this
-    /// for efficiency. The default calls [`Self::get`] sequentially.
-    ///
-    /// Results are returned in the same order as the input `metas`.
     /// Fetch multiple change requests in a single operation.
     ///
     /// Forges that support batching (e.g. GitHub via GraphQL) override this
@@ -114,10 +123,16 @@ pub trait Forge: Send + Sync {
     ///
     /// Useful for discovering existing CRs on the forge that are not yet
     /// tracked locally.
+    ///
+    /// `source_repo` narrows the search to cross-repo (fork) change requests
+    /// whose source branch lives in the specified repository. The format is
+    /// forge-specific and matches [`CreateParams::source_repo`]. When `None`,
+    /// the search is limited to same-repo change requests.
     fn find<'a>(
         &'a self,
         source_branch: Option<&'a str>,
         target_branch: Option<&'a str>,
+        source_repo: Option<&'a str>,
     ) -> BoxFuture<'a, ForgeResults>;
 
     /// Update the title and/or body of an existing change request.
@@ -157,12 +172,16 @@ pub trait Forge: Send + Sync {
     ///
     /// This is a convenience wrapper around [`Forge::find`] that extracts
     /// [`ForgeMeta`] from each result.
+    ///
+    /// `source_repo` is forwarded to [`Forge::find`] unchanged; see its
+    /// documentation for the forge-specific format.
     fn find_change_requests<'a>(
         &'a self,
         source_branch: &'a str,
+        source_repo: Option<&'a str>,
     ) -> BoxFuture<'a, Result<Vec<ForgeMeta>, Box<dyn std::error::Error>>> {
         Box::pin(async move {
-            let crs = self.find(Some(source_branch), None).await?;
+            let crs = self.find(Some(source_branch), None, source_repo).await?;
             Ok(crs.iter().map(|cr| cr.to_forge_meta()).collect())
         })
     }

--- a/lib/src/forge/detect.rs
+++ b/lib/src/forge/detect.rs
@@ -7,6 +7,8 @@ use jj_lib::store::Store;
 use thiserror::Error;
 use url::Url;
 
+use crate::protos::change_request::ForgeMeta;
+
 use super::Forge;
 use super::github::{GitHubForge, build_octocrab_for_github};
 
@@ -44,6 +46,26 @@ pub struct DetectionResult {
     pub forges: HashMap<String, Box<dyn Forge>>,
     /// Remotes with a parseable owner/repo but no recognised forge hostname.
     pub unmatched: Vec<UnmatchedRemote>,
+}
+
+impl DetectionResult {
+    /// Resolve the forge instance that owns a change request.
+    ///
+    /// For cross-repo (fork) PRs the `target_repo` stored in [`ForgeMeta`]
+    /// identifies where the CR lives (`"upstream-org/repo"`). This method
+    /// looks through the detected forges for an instance whose
+    /// [`Forge::repo_id`] matches that target.
+    ///
+    /// When `target_repo` is empty (same-repo CR) or no match is found,
+    /// returns `None` so the caller can fall back to the default forge
+    /// selection (e.g. by tracked remote).
+    pub fn resolve_forge_for_meta(&self, meta: &ForgeMeta) -> Option<&dyn Forge> {
+        let target = meta.target_repo()?;
+        self.forges
+            .values()
+            .find(|f| f.repo_id() == target)
+            .map(|f| f.as_ref())
+    }
 }
 
 /// Errors that can occur when detecting forges from git remotes.

--- a/lib/src/forge/github.rs
+++ b/lib/src/forge/github.rs
@@ -10,6 +10,7 @@ use url::Url;
 use crate::forge::{
     BoxFuture, ChangeRequest, ChangeStatus, CreateParams, Forge, ForgeResult, ForgeResults,
 };
+
 use crate::protos::change_request::forge_meta::Forge as ForgeOneof;
 use crate::protos::change_request::{ForgeMeta, GitHubMeta};
 
@@ -316,6 +317,19 @@ impl GitHubForge {
             _ => Err(GitHubError::WrongForge),
         }
     }
+
+    /// Format a branch reference for the GitHub API `head` parameter.
+    ///
+    /// GitHub requires `"owner:branch"` format for pull request head filters.
+    /// `source_repo` carries the full [`Forge::repo_id`] (`"owner/repo"`);
+    /// only the owner prefix is extracted. When `source_repo` is `None`,
+    /// falls back to this forge's own owner (same-repo PR).
+    fn format_head_ref(&self, branch: &str, source_repo: Option<&str>) -> String {
+        let owner = source_repo
+            .and_then(|r| r.split('/').next())
+            .unwrap_or(&self.owner);
+        format!("{owner}:{branch}")
+    }
 }
 
 /// Build a [`GitHubChangeRequest`] from an octocrab [`PullRequest`] response.
@@ -362,11 +376,17 @@ fn github_cr_from_pr(pr: &PullRequest, host: &str) -> GitHubChangeRequest {
 }
 
 impl Forge for GitHubForge {
+    fn repo_id(&self) -> String {
+        format!("{}/{}", self.owner, self.repo)
+    }
+
     fn create<'a>(&'a self, params: CreateParams<'a>) -> BoxFuture<'a, ForgeResult> {
         Box::pin(async move {
             let pulls = self.client.pulls(&self.owner, &self.repo);
+            let head = self.format_head_ref(params.source_branch, params.source_repo);
+
             let builder = pulls
-                .create(params.title, params.source_branch, params.target_branch)
+                .create(params.title, head, params.target_branch)
                 .draft(Some(params.is_draft))
                 .body::<String>(params.body.map(String::from));
 
@@ -392,6 +412,7 @@ impl Forge for GitHubForge {
         &'a self,
         source_branch: Option<&'a str>,
         target_branch: Option<&'a str>,
+        source_repo: Option<&'a str>,
     ) -> BoxFuture<'a, ForgeResults> {
         Box::pin(async move {
             let pulls = self.client.pulls(&self.owner, &self.repo);
@@ -401,8 +422,7 @@ impl Forge for GitHubForge {
                 .per_page(100);
 
             if let Some(head) = source_branch {
-                // GitHub requires "owner:branch" format for the head filter.
-                builder = builder.head(format!("{}:{head}", self.owner));
+                builder = builder.head(self.format_head_ref(head, source_repo));
             }
             if let Some(base) = target_branch {
                 builder = builder.base(base);
@@ -927,6 +947,7 @@ mod tests {
                 title: "New PR",
                 body: Some("body text"),
                 is_draft: false,
+                source_repo: None,
             })
             .await
             .unwrap();
@@ -949,7 +970,7 @@ mod tests {
             .await;
 
         let forge = mock_forge(&mock_server.uri());
-        let results = forge.find(None, None).await.unwrap();
+        let results = forge.find(None, None, None).await.unwrap();
 
         assert_eq!(results.len(), 2);
         assert_eq!(results[0].id(), "1");
@@ -968,7 +989,7 @@ mod tests {
             .await;
 
         let forge = mock_forge(&mock_server.uri());
-        let results = forge.find(None, None).await.unwrap();
+        let results = forge.find(None, None, None).await.unwrap();
 
         assert!(results.is_empty());
     }
@@ -1345,5 +1366,139 @@ mod tests {
         assert!(query_str.contains("repository(owner: \"owner\", name: \"repo\")"));
         assert!(query_str.contains("pr0: pullRequest(number: 42)"));
         assert!(query_str.contains("pr1: pullRequest(number: 43)"));
+    }
+
+    // -- repo_id() --
+
+    #[tokio::test]
+    async fn repo_id_returns_owner_slash_repo() {
+        let forge = mock_forge("http://localhost");
+        assert_eq!(forge.repo_id(), format!("{OWNER}/{REPO}"));
+    }
+
+    // -- create() with source_repo (cross-repo PR) --
+
+    #[tokio::test]
+    async fn create_cross_repo_pr_formats_head_as_owner_colon_branch() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(format!("/repos/{OWNER}/{REPO}/pulls")))
+            .and(wiremock::matchers::body_partial_json(json!({
+                "head": "fork-user:feature-branch"
+            })))
+            .respond_with(
+                ResponseTemplate::new(201).set_body_json(pr_json(77, "open", false, false)),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let forge = mock_forge(&mock_server.uri());
+        // source_repo is the fork's full repo_id; create() extracts the owner.
+        let cr = forge
+            .create(CreateParams {
+                source_branch: "feature-branch",
+                target_branch: "main",
+                title: "Cross-repo PR",
+                body: None,
+                is_draft: false,
+                source_repo: Some("fork-user/some-repo"),
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(cr.id(), "77");
+    }
+
+    #[tokio::test]
+    async fn create_same_repo_pr_uses_owner_colon_branch() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(format!("/repos/{OWNER}/{REPO}/pulls")))
+            .and(wiremock::matchers::body_partial_json(json!({
+                "head": format!("{OWNER}:feature-branch")
+            })))
+            .respond_with(
+                ResponseTemplate::new(201).set_body_json(pr_json(88, "open", false, false)),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let forge = mock_forge(&mock_server.uri());
+        let cr = forge
+            .create(CreateParams {
+                source_branch: "feature-branch",
+                target_branch: "main",
+                title: "Same-repo PR",
+                body: None,
+                is_draft: false,
+                source_repo: None,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(cr.id(), "88");
+    }
+
+    // -- find() with source_repo --
+
+    #[tokio::test]
+    async fn find_with_source_repo_uses_fork_owner_in_head_filter() {
+        let mock_server = MockServer::start().await;
+        // source_repo is "fork-user/some-repo"; owner "fork-user" is extracted.
+        Mock::given(method("GET"))
+            .and(path(format!("/repos/{OWNER}/{REPO}/pulls")))
+            .and(wiremock::matchers::query_param(
+                "head",
+                "fork-user:feature-branch",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+            .mount(&mock_server)
+            .await;
+
+        let forge = mock_forge(&mock_server.uri());
+        let results = forge
+            .find(Some("feature-branch"), None, Some("fork-user/some-repo"))
+            .await
+            .unwrap();
+
+        assert!(results.is_empty());
+    }
+
+    #[tokio::test]
+    async fn find_without_source_repo_uses_forge_owner_in_head_filter() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(format!("/repos/{OWNER}/{REPO}/pulls")))
+            .and(wiremock::matchers::query_param(
+                "head",
+                format!("{OWNER}:feature-branch"),
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+            .mount(&mock_server)
+            .await;
+
+        let forge = mock_forge(&mock_server.uri());
+        let results = forge
+            .find(Some("feature-branch"), None, None)
+            .await
+            .unwrap();
+
+        assert!(results.is_empty());
+    }
+
+    // -- format_head_ref tests --
+
+    #[tokio::test]
+    async fn format_head_ref_with_source_repo_extracts_owner() {
+        let forge = mock_forge("http://unused");
+        let head = forge.format_head_ref("feat", Some("fork-user/some-repo"));
+        assert_eq!(head, "fork-user:feat");
+    }
+
+    #[tokio::test]
+    async fn format_head_ref_without_source_repo_uses_forge_owner() {
+        let forge = mock_forge("http://unused");
+        let head = forge.format_head_ref("feat", None);
+        assert_eq!(head, format!("{OWNER}:feat"));
     }
 }

--- a/lib/src/store/change_request.rs
+++ b/lib/src/store/change_request.rs
@@ -23,6 +23,18 @@ impl ForgeMeta {
         }
     }
 
+    /// Return the target repository identity stored in the metadata.
+    ///
+    /// For cross-repo (fork) change requests this identifies where the CR
+    /// lives (e.g. `"upstream-org/repo"`). Returns `None` when the field is
+    /// empty (same-repo CR) or the forge variant is absent.
+    pub fn target_repo(&self) -> Option<&str> {
+        match &self.forge {
+            Some(ForgeOneof::Github(gh)) if !gh.target_repo.is_empty() => Some(&gh.target_repo),
+            _ => None,
+        }
+    }
+
     /// Return the comment ID stored in the forge-specific metadata, if any.
     pub fn comment_id(&self) -> Option<u64> {
         match &self.forge {


### PR DESCRIPTION
Enable fork workflows where branches are pushed to a personal fork
while change requests target an upstream repository.

Fork mode activates automatically when two distinct remotes are
configured (e.g. origin for the fork, upstream for the target).
The upstream remote can also be set explicitly via
`spice.upstream-remote` config.

Commands affected:
- `stack submit`: creates PRs against the upstream forge, passing the
  fork identity so GitHub formats cross-repo head refs correctly.
- `stack sync`: discovers cross-repo PRs by querying upstream forges
  with the fork as a source filter.
- `stack log`: resolves forge instances via the CR's target_repo
  metadata for correct status display on fork PRs.