### PR TITLE
feat: add graph-style stack comments for GitHub PRs

### DIFF
--- a/cli/src/commands/stack_submit.rs
+++ b/cli/src/commands/stack_submit.rs
@@ -199,7 +199,7 @@ pub async fn run(
     }
 
     // Post stack-trace comments on all CRs concurrently.
-    post_stack_comments(forge, &graph, &mut state).await?;
+    post_stack_comments(forge, &graph, &mut state, trunk_name).await?;
 
     // Persist CRs and comment IDs to disk.
     cr_store.save(&state)?;
@@ -520,6 +520,7 @@ async fn post_stack_comments(
     forge: &dyn Forge,
     graph: &BookmarkGraph<'_>,
     state: &mut ChangeRequests,
+    trunk_name: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Build comment text + metadata for each bookmark in one pass.
     let comment_tasks: Vec<(String, ForgeMeta, String)> = graph
@@ -532,7 +533,9 @@ async fn post_stack_comments(
                 .get(name)
                 .ok_or_else(|| format!("no change request found for bookmark '{name}'"))?
                 .clone();
-            let comment_text = Comment::new(bookmark, graph, state).to_string()?;
+            let comment_text = Comment::new(bookmark, graph, state)
+                .with_trunk(trunk_name)
+                .to_string()?;
             Ok((name.to_string(), meta, comment_text))
         })
         .collect::<Result<Vec<_>, Box<dyn std::error::Error>>>()?;

--- a/lib/src/comments.rs
+++ b/lib/src/comments.rs
@@ -5,16 +5,29 @@ use thiserror::Error;
 
 use crate::bookmark::Bookmark;
 use crate::bookmark::graph::BookmarkGraph;
+use crate::forge::ChangeStatus;
 use crate::protos::change_request::forge_meta::Forge;
 use crate::protos::change_request::{ChangeRequests, ForgeMeta};
 
-const INDENT: &str = "  ";
 const JJ_SPICE_URL: &str = "https://github.com/alejoborbo/jj-spice";
-const HEADER_LINE: &str = "This change belongs to the following stack:\n";
-const MANAGED_BY_COMMENT_LINE: &str = formatcp!(
-    "\n<sub>Change managed by [jj-spice]({}).</sub>",
+const MANAGED_BY_HTML: &str = formatcp!(
+    "\n<sub>Change managed by <a href=\"{}\">jj-spice</a>.</sub>",
     JJ_SPICE_URL
 );
+
+/// Node symbol used for every bookmark in the graph.
+const NODE_SYMBOL: &str = "○";
+
+/// Node symbol used for the trunk (immutable) bookmark.
+const TRUNK_SYMBOL: &str = "◆";
+
+/// Live data for a single change request, used to enrich graph comments.
+#[derive(Debug, Clone)]
+pub struct LiveCrData {
+    pub status: ChangeStatus,
+    pub title: String,
+    pub url: String,
+}
 
 #[derive(Debug, Error)]
 pub enum CommentError {
@@ -28,12 +41,21 @@ pub enum CommentError {
     NoTargetBranchFound,
 }
 
-/// Struct for creating change request comments.
-/// Those comments would be added to the change request to vizualize the stack trace.
+/// Renders a stack-trace comment for a change request.
+///
+/// The comment is an ASCII-art graph inside `<pre>` with `<a>` hyperlinks,
+/// visually matching the `jj-spice stack log` output with emoji status
+/// badges and clickable CR links.
+///
+/// Graph rendering is forge-agnostic: forge-specific data (CR labels and
+/// fallback URLs) is extracted once into [`CommentNode`] so the rendering
+/// logic is shared across GitHub PRs and GitLab MRs.
 pub struct Comment<'a> {
     current_bookmark: &'a Bookmark<'a>,
     graph: &'a BookmarkGraph<'a>,
     change_requests: &'a ChangeRequests,
+    trunk_name: Option<&'a str>,
+    live_data: Option<&'a BTreeMap<String, LiveCrData>>,
 }
 
 impl<'a> Comment<'a> {
@@ -46,30 +68,81 @@ impl<'a> Comment<'a> {
             current_bookmark,
             graph,
             change_requests,
+            trunk_name: None,
+            live_data: None,
         }
     }
 
+    /// Set the trunk bookmark name (shown at the bottom of the graph).
+    pub fn with_trunk(mut self, trunk_name: &'a str) -> Self {
+        self.trunk_name = Some(trunk_name);
+        self
+    }
+
+    /// Provide live change request data for richer graph output.
+    pub fn with_live_data(mut self, data: &'a BTreeMap<String, LiveCrData>) -> Self {
+        self.live_data = Some(data);
+        self
+    }
+
+    /// Render the comment as an ASCII-art graph inside `<pre>` with `<a>` hyperlinks.
+    ///
+    /// Produces output in the same visual style as `jj-spice stack log`:
+    /// vertical graph with Unicode box-drawing characters, bookmark nodes
+    /// rendered top-to-bottom (leaf first, root last, trunk at bottom).
     pub fn to_string(&self) -> Result<String, CommentError> {
-        let mut comment = String::from(HEADER_LINE);
+        let ascendant_to_crs = self.build_ascendant_map()?;
+        let ordered = self.collect_ordered_nodes(&ascendant_to_crs)?;
 
-        // Map from ascendant bookmark name (source_branch) to its descendant change requests.
-        // Uses each CR's target_branch to find its parent CR.
-        let ascendant_to_crs: BTreeMap<String, Vec<&ForgeMeta>> = {
-            let mut map: BTreeMap<String, Vec<&ForgeMeta>> = BTreeMap::new();
-            for meta in self.change_requests.by_bookmark.values() {
-                let target_branch = meta
-                    .target_branch()
-                    .ok_or(CommentError::NoBaseBranchFound)?;
+        let mut output = String::from("This change belongs to the following stack:\n<pre>\n");
 
-                if self.change_requests.get(target_branch).is_some() {
-                    map.entry(target_branch.to_string()).or_default().push(meta);
-                }
+        for (i, node) in ordered.iter().enumerate() {
+            let is_current = node.source_branch == self.current_bookmark.name();
+            let here_marker = if is_current { "  👈" } else { "" };
+
+            let link = self.format_cr_link(node);
+            let status = self.format_status_emoji(node);
+
+            output.push_str(&format!(
+                "{}  {}{}{}\n",
+                NODE_SYMBOL, link, status, here_marker,
+            ));
+
+            // Title line (when live data is available).
+            if let Some(title) = self.node_title(node)
+                && !title.is_empty()
+            {
+                output.push_str(&format!("│  {}\n", html_escape(title)));
             }
-            map
-        };
 
-        // A queue of bookmark, and the depth of the bookmark in the stack trace
-        let mut queue: Vec<(&ForgeMeta, usize)> = self
+            // Connector to the next node.
+            if i < ordered.len() - 1 {
+                output.push_str("│\n");
+            }
+        }
+
+        // Trunk node at the bottom.
+        if let Some(trunk) = self.trunk_name {
+            if !ordered.is_empty() {
+                output.push_str("│\n");
+            }
+            output.push_str(&format!("{}  {}\n", TRUNK_SYMBOL, html_escape(trunk)));
+        }
+
+        output.push_str("</pre>\n");
+        output.push_str(MANAGED_BY_HTML);
+        Ok(output)
+    }
+
+    /// Collect nodes in reversed topological order (leaf-first, root-last).
+    fn collect_ordered_nodes(
+        &self,
+        ascendant_to_crs: &BTreeMap<String, Vec<&ForgeMeta>>,
+    ) -> Result<Vec<CommentNode>, CommentError> {
+        let mut nodes = Vec::new();
+        let mut visited = Vec::new();
+
+        let mut stack: Vec<&ForgeMeta> = self
             .graph
             .root_bookmarks
             .iter()
@@ -77,55 +150,147 @@ impl<'a> Comment<'a> {
                 self.change_requests
                     .get(b)
                     .ok_or_else(|| CommentError::NoChangeRequestFound(b.clone()))
-                    .map(|meta| (meta, 0))
             })
             .collect::<Result<Vec<_>, _>>()?;
-        let mut visited = Vec::new();
 
-        // Go through the bookmarks in a depth first order, and add comments to the change request
-        while let Some((meta, depth)) = queue.pop() {
+        while let Some(meta) = stack.pop() {
             if visited.contains(&meta) {
                 continue;
             }
             visited.push(meta);
 
-            // Fetch source branch, which is the current bookmark
             let source_branch = meta
                 .source_branch()
                 .ok_or(CommentError::NoTargetBranchFound)?;
 
-            // Add the comment to the change request
-            let indent = INDENT.repeat(depth);
-            let id = self
-                .forge_meta_id(meta)
-                .ok_or_else(|| CommentError::NoForgeMetadataFound(source_branch.to_string()))?;
+            let (cr_label, cr_url) = Self::extract_cr_info(meta);
 
-            // Add the change request to the comment
-            comment.push_str(format!("{}- {}", indent, id).as_str());
-            if source_branch == self.current_bookmark.name() {
-                comment.push_str(" 👈 you are here!");
-            }
-            comment.push('\n');
+            nodes.push(CommentNode {
+                source_branch: source_branch.to_string(),
+                cr_label,
+                cr_url,
+            });
 
-            // Add the next bookmarks of the bookmark to the queue
             for next in ascendant_to_crs.get(source_branch).unwrap_or(&vec![]) {
-                queue.push((next, depth + 1));
+                stack.push(next);
             }
         }
 
-        // Add a link to the repo URL
-        comment.push_str(MANAGED_BY_COMMENT_LINE);
-
-        Ok(comment)
+        // Reverse: DFS from roots produces root-first, we want leaf-first.
+        nodes.reverse();
+        Ok(nodes)
     }
 
-    fn forge_meta_id(&self, meta: &ForgeMeta) -> Option<String> {
-        match &meta.forge {
-            Some(Forge::Github(gh)) => Some(format!("#{}", gh.number)),
-            Some(Forge::Gitlab(gl)) => Some(format!("!{}", gl.iid)),
-            None => None,
+    /// Build a map from ascendant bookmark name to its descendant ForgeMeta entries.
+    fn build_ascendant_map(&self) -> Result<BTreeMap<String, Vec<&ForgeMeta>>, CommentError> {
+        let mut map: BTreeMap<String, Vec<&ForgeMeta>> = BTreeMap::new();
+        for meta in self.change_requests.by_bookmark.values() {
+            let target_branch = meta
+                .target_branch()
+                .ok_or(CommentError::NoBaseBranchFound)?;
+
+            if self.change_requests.get(target_branch).is_some() {
+                map.entry(target_branch.to_string()).or_default().push(meta);
+            }
+        }
+        Ok(map)
+    }
+
+    /// Format a CR reference as a clickable `<a>` tag.
+    ///
+    /// When live data is available, uses the authoritative URL from the forge
+    /// API. Otherwise falls back to the URL built from stored metadata (only
+    /// available for forges that carry enough info, e.g. GitHub's `target_repo`).
+    fn format_cr_link(&self, node: &CommentNode) -> String {
+        let bookmark = html_escape(&node.source_branch);
+
+        if let Some(live) = self.live_data.and_then(|d| d.get(&node.source_branch)) {
+            let label = match &node.cr_label {
+                Some(l) => format!("{} {}", bookmark, l),
+                None => bookmark.to_string(),
+            };
+            format!("<a href=\"{}\">{}</a>", html_escape(&live.url), label)
+        } else if let (Some(label), Some(url)) = (&node.cr_label, &node.cr_url) {
+            format!(
+                "<a href=\"{}\">{} {}</a>",
+                html_escape(url),
+                bookmark,
+                label,
+            )
+        } else if let Some(label) = &node.cr_label {
+            format!("{} {}", bookmark, label)
+        } else {
+            bookmark.to_string()
         }
     }
+
+    /// Format an emoji status badge for the node.
+    fn format_status_emoji(&self, node: &CommentNode) -> String {
+        if let Some(live) = self.live_data.and_then(|d| d.get(&node.source_branch)) {
+            let emoji = match live.status {
+                ChangeStatus::Open => "🟢 Open",
+                ChangeStatus::Draft => "🟡 Draft",
+                ChangeStatus::Merged => "🟣 Merged",
+                ChangeStatus::Closed => "🔴 Closed",
+            };
+            format!(" {}", emoji)
+        } else {
+            String::new()
+        }
+    }
+
+    /// Get the title for a node from live data, if available.
+    fn node_title<'b>(&'b self, node: &CommentNode) -> Option<&'b str> {
+        self.live_data
+            .and_then(|d| d.get(&node.source_branch))
+            .map(|live| live.title.as_str())
+    }
+
+    /// Extract forge-agnostic CR display label and fallback URL from metadata.
+    ///
+    /// Returns `(cr_label, cr_url)` where `cr_label` is the human-readable
+    /// identifier (e.g. `"#42"` for GitHub, `"!42"` for GitLab) and `cr_url`
+    /// is a best-effort direct URL when enough info is stored in the proto.
+    fn extract_cr_info(meta: &ForgeMeta) -> (Option<String>, Option<String>) {
+        match &meta.forge {
+            Some(Forge::Github(gh)) => {
+                let label = format!("#{}", gh.number);
+                let url = if !gh.target_repo.is_empty() {
+                    Some(format!(
+                        "https://github.com/{}/pull/{}",
+                        gh.target_repo, gh.number,
+                    ))
+                } else {
+                    None
+                };
+                (Some(label), url)
+            }
+            Some(Forge::Gitlab(gl)) => {
+                let label = format!("!{}", gl.iid);
+                // GitLab proto stores project IDs rather than path strings,
+                // so we cannot construct a fallback URL from metadata alone.
+                (Some(label), None)
+            }
+            None => (None, None),
+        }
+    }
+}
+
+/// Forge-agnostic intermediate representation of a graph node.
+struct CommentNode {
+    source_branch: String,
+    /// Human-readable CR identifier (e.g. `"#42"` for GitHub, `"!42"` for GitLab).
+    cr_label: Option<String>,
+    /// Best-effort direct URL to the CR, built from stored metadata.
+    cr_url: Option<String>,
+}
+
+/// Escape HTML special characters.
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
 }
 
 #[cfg(test)]
@@ -138,7 +303,7 @@ mod tests {
     use crate::bookmark::Bookmark;
     use crate::bookmark::graph::BookmarkGraph;
     use crate::protos::change_request::forge_meta::Forge as ForgeOneof;
-    use crate::protos::change_request::{ChangeRequests, GitHubMeta};
+    use crate::protos::change_request::{ChangeRequests, GitHubMeta, GitLabMeta};
 
     fn make_bookmark(name: &str) -> Bookmark<'static> {
         Bookmark::new(
@@ -150,7 +315,6 @@ mod tests {
         )
     }
 
-    /// Build a ForgeMeta where `source_branch` = bookmark name, `target_branch` = parent bookmark.
     fn github_meta(number: u64, source_branch: &str, target_branch: &str) -> ForgeMeta {
         ForgeMeta {
             forge: Some(ForgeOneof::Github(GitHubMeta {
@@ -165,7 +329,19 @@ mod tests {
         }
     }
 
-    /// Entries: (bookmark_name, pr_number, target_branch).
+    fn gitlab_meta(iid: u64, source_branch: &str, target_branch: &str) -> ForgeMeta {
+        ForgeMeta {
+            forge: Some(ForgeOneof::Gitlab(GitLabMeta {
+                id: iid * 100,
+                iid,
+                source_branch: source_branch.into(),
+                target_branch: target_branch.into(),
+                source_project_id: None,
+                comment_id: None,
+            })),
+        }
+    }
+
     fn make_change_requests(entries: Vec<(&str, u64, &str)>) -> ChangeRequests {
         let mut crs = ChangeRequests::default();
         for (name, number, target) in entries {
@@ -174,25 +350,55 @@ mod tests {
         crs
     }
 
-    // -- to_string tests --
+    fn make_gitlab_change_requests(entries: Vec<(&str, u64, &str)>) -> ChangeRequests {
+        let mut crs = ChangeRequests::default();
+        for (name, iid, target) in entries {
+            crs.set(name.to_string(), gitlab_meta(iid, name, target));
+        }
+        crs
+    }
+
+    fn make_live_data(
+        entries: Vec<(&str, ChangeStatus, &str, &str)>,
+    ) -> BTreeMap<String, LiveCrData> {
+        entries
+            .into_iter()
+            .map(|(name, status, title, url)| {
+                (
+                    name.to_string(),
+                    LiveCrData {
+                        status,
+                        title: title.to_string(),
+                        url: url.to_string(),
+                    },
+                )
+            })
+            .collect()
+    }
+
+    // -- Structure tests (GitHub) --
 
     #[test]
-    fn single_bookmark_stack() {
+    fn single_bookmark_graph() {
         let bookmark = make_bookmark("feat-a");
         let graph = BookmarkGraph::for_testing(vec!["feat-a".into()], BTreeMap::new());
         let crs = make_change_requests(vec![("feat-a", 1, "main")]);
 
-        let comment = Comment::new(&bookmark, &graph, &crs);
+        let comment = Comment::new(&bookmark, &graph, &crs).with_trunk("main");
         let output = comment.to_string().unwrap();
 
-        assert!(output.contains("- #1 👈 you are here!"));
-        assert!(output.contains("This change belongs to the following stack:"));
-        assert!(output.contains("jj-spice"));
+        assert!(output.contains("<pre>"));
+        assert!(output.contains("</pre>"));
+        assert!(output.contains("○"));
+        assert!(output.contains("◆  main"));
+        assert!(output.contains("feat-a #1"));
+        assert!(output.contains("👈"));
+        assert!(output.contains("<a href="));
+        assert!(output.contains("jj-spice</a>"));
     }
 
     #[test]
-    fn linear_stack_marks_current_bookmark() {
-        // root -> mid -> leaf (target_branch chains: leaf→mid, mid→root, root→main)
+    fn linear_stack_ordering() {
         let current = make_bookmark("mid");
         let graph = BookmarkGraph::for_testing(vec!["root".into()], BTreeMap::new());
         let crs = make_change_requests(vec![
@@ -201,13 +407,21 @@ mod tests {
             ("leaf", 12, "mid"),
         ]);
 
-        let comment = Comment::new(&current, &graph, &crs);
+        let comment = Comment::new(&current, &graph, &crs).with_trunk("main");
         let output = comment.to_string().unwrap();
 
-        // root at depth 0, mid at depth 1, leaf at depth 2
-        assert!(output.contains("- #10\n"));
-        assert!(output.contains("  - #11 👈 you are here!\n"));
-        assert!(output.contains("    - #12\n"));
+        // Leaf at top, root at bottom before trunk.
+        let leaf_pos = output.find("leaf #12").unwrap();
+        let mid_pos = output.find("mid #11").unwrap();
+        let root_pos = output.find("root #10").unwrap();
+        let trunk_pos = output.find("◆  main").unwrap();
+
+        assert!(leaf_pos < mid_pos, "leaf should be above mid");
+        assert!(mid_pos < root_pos, "mid should be above root");
+        assert!(root_pos < trunk_pos, "root should be above trunk");
+
+        // Current bookmark marked.
+        assert!(output.contains("mid #11</a>  👈"));
     }
 
     #[test]
@@ -216,16 +430,241 @@ mod tests {
         let graph = BookmarkGraph::for_testing(vec!["root".into()], BTreeMap::new());
         let crs = make_change_requests(vec![("root", 1, "main"), ("child", 2, "root")]);
 
-        let comment = Comment::new(&current, &graph, &crs);
+        let comment = Comment::new(&current, &graph, &crs).with_trunk("main");
         let output = comment.to_string().unwrap();
 
-        assert!(output.contains("- #1 👈 you are here!\n"));
-        assert!(output.contains("  - #2\n"));
+        assert!(output.contains("root #1</a>  👈"));
+        // Child above root.
+        let child_pos = output.find("child #2").unwrap();
+        let root_pos = output.find("root #1").unwrap();
+        assert!(child_pos < root_pos);
+    }
+
+    // -- Live data tests --
+
+    #[test]
+    fn live_data_shows_status_and_title() {
+        let current = make_bookmark("feat-a");
+        let graph = BookmarkGraph::for_testing(vec!["feat-a".into()], BTreeMap::new());
+        let crs = make_change_requests(vec![("feat-a", 42, "main")]);
+        let live = make_live_data(vec![(
+            "feat-a",
+            ChangeStatus::Open,
+            "Add cool feature",
+            "https://github.com/owner/repo/pull/42",
+        )]);
+
+        let comment = Comment::new(&current, &graph, &crs)
+            .with_trunk("main")
+            .with_live_data(&live);
+        let output = comment.to_string().unwrap();
+
+        assert!(output.contains("🟢 Open"));
+        assert!(output.contains("Add cool feature"));
+        assert!(output.contains("https://github.com/owner/repo/pull/42"));
     }
 
     #[test]
+    fn live_data_draft_and_merged() {
+        let current = make_bookmark("feat-b");
+        let graph = BookmarkGraph::for_testing(vec!["feat-a".into()], BTreeMap::new());
+        let crs = make_change_requests(vec![("feat-a", 10, "main"), ("feat-b", 11, "feat-a")]);
+        let live = make_live_data(vec![
+            (
+                "feat-a",
+                ChangeStatus::Merged,
+                "Base feature",
+                "https://github.com/owner/repo/pull/10",
+            ),
+            (
+                "feat-b",
+                ChangeStatus::Draft,
+                "WIP feature",
+                "https://github.com/owner/repo/pull/11",
+            ),
+        ]);
+
+        let comment = Comment::new(&current, &graph, &crs).with_live_data(&live);
+        let output = comment.to_string().unwrap();
+
+        assert!(output.contains("🟣 Merged"));
+        assert!(output.contains("🟡 Draft"));
+    }
+
+    #[test]
+    fn live_data_closed() {
+        let current = make_bookmark("feat");
+        let graph = BookmarkGraph::for_testing(vec!["feat".into()], BTreeMap::new());
+        let crs = make_change_requests(vec![("feat", 5, "main")]);
+        let live = make_live_data(vec![(
+            "feat",
+            ChangeStatus::Closed,
+            "Abandoned",
+            "https://github.com/owner/repo/pull/5",
+        )]);
+
+        let comment = Comment::new(&current, &graph, &crs).with_live_data(&live);
+        let output = comment.to_string().unwrap();
+
+        assert!(output.contains("🔴 Closed"));
+    }
+
+    // -- Graph structure tests --
+
+    #[test]
+    fn without_trunk_omits_diamond() {
+        let bookmark = make_bookmark("feat-a");
+        let graph = BookmarkGraph::for_testing(vec!["feat-a".into()], BTreeMap::new());
+        let crs = make_change_requests(vec![("feat-a", 1, "main")]);
+
+        let comment = Comment::new(&bookmark, &graph, &crs);
+        let output = comment.to_string().unwrap();
+
+        assert!(output.contains("○"));
+        assert!(!output.contains("◆"));
+    }
+
+    #[test]
+    fn connector_lines_between_nodes() {
+        let bookmark = make_bookmark("root");
+        let graph = BookmarkGraph::for_testing(vec!["root".into()], BTreeMap::new());
+        let crs = make_change_requests(vec![("root", 1, "main"), ("child", 2, "root")]);
+
+        let comment = Comment::new(&bookmark, &graph, &crs).with_trunk("main");
+        let output = comment.to_string().unwrap();
+
+        assert!(output.contains("│\n"));
+    }
+
+    #[test]
+    fn forking_stack_both_children_above_root() {
+        let current = make_bookmark("root");
+        let graph = BookmarkGraph::for_testing(vec!["root".into()], BTreeMap::new());
+        let crs = make_change_requests(vec![
+            ("root", 1, "main"),
+            ("child-a", 2, "root"),
+            ("child-b", 3, "root"),
+        ]);
+
+        let comment = Comment::new(&current, &graph, &crs).with_trunk("main");
+        let output = comment.to_string().unwrap();
+
+        assert!(output.contains("child-a #2"));
+        assert!(output.contains("child-b #3"));
+        assert!(output.contains("root #1"));
+
+        let child_a_pos = output.find("child-a").unwrap();
+        let child_b_pos = output.find("child-b").unwrap();
+        let root_pos = output.find("root #1").unwrap();
+
+        assert!(child_a_pos < root_pos, "child-a should be above root");
+        assert!(child_b_pos < root_pos, "child-b should be above root");
+    }
+
+    // -- GitLab tests --
+
+    #[test]
+    fn single_gitlab_mr_graph() {
+        let bookmark = make_bookmark("feat-a");
+        let graph = BookmarkGraph::for_testing(vec!["feat-a".into()], BTreeMap::new());
+        let crs = make_gitlab_change_requests(vec![("feat-a", 1, "main")]);
+
+        let comment = Comment::new(&bookmark, &graph, &crs).with_trunk("main");
+        let output = comment.to_string().unwrap();
+
+        assert!(output.contains("feat-a !1"));
+        assert!(output.contains("○"));
+        assert!(output.contains("◆  main"));
+        assert!(output.contains("👈"));
+        // GitLab has no fallback URL from metadata alone, so no CR link
+        // inside the graph (the footer still has the jj-spice link).
+        let pre_block = output.split("</pre>").next().unwrap();
+        assert!(!pre_block.contains("<a href="));
+    }
+
+    #[test]
+    fn linear_gitlab_stack_ordering() {
+        let current = make_bookmark("mid");
+        let graph = BookmarkGraph::for_testing(vec!["root".into()], BTreeMap::new());
+        let crs = make_gitlab_change_requests(vec![
+            ("root", 10, "main"),
+            ("mid", 11, "root"),
+            ("leaf", 12, "mid"),
+        ]);
+
+        let comment = Comment::new(&current, &graph, &crs).with_trunk("main");
+        let output = comment.to_string().unwrap();
+
+        let leaf_pos = output.find("leaf !12").unwrap();
+        let mid_pos = output.find("mid !11").unwrap();
+        let root_pos = output.find("root !10").unwrap();
+        let trunk_pos = output.find("◆  main").unwrap();
+
+        assert!(leaf_pos < mid_pos, "leaf should be above mid");
+        assert!(mid_pos < root_pos, "mid should be above root");
+        assert!(root_pos < trunk_pos, "root should be above trunk");
+
+        // Current bookmark marked.
+        assert!(output.contains("mid !11  👈"));
+    }
+
+    #[test]
+    fn gitlab_live_data_produces_clickable_links() {
+        let current = make_bookmark("feat-a");
+        let graph = BookmarkGraph::for_testing(vec!["feat-a".into()], BTreeMap::new());
+        let crs = make_gitlab_change_requests(vec![("feat-a", 42, "main")]);
+        let live = make_live_data(vec![(
+            "feat-a",
+            ChangeStatus::Open,
+            "Add cool feature",
+            "https://gitlab.com/g/p/-/merge_requests/42",
+        )]);
+
+        let comment = Comment::new(&current, &graph, &crs)
+            .with_trunk("main")
+            .with_live_data(&live);
+        let output = comment.to_string().unwrap();
+
+        assert!(output.contains("<a href=\"https://gitlab.com/g/p/-/merge_requests/42\">"));
+        assert!(output.contains("feat-a !42"));
+        assert!(output.contains("🟢 Open"));
+        assert!(output.contains("Add cool feature"));
+    }
+
+    // -- Security tests --
+
+    #[test]
+    fn html_escapes_special_chars() {
+        let bookmark = make_bookmark("feat<xss>");
+        let graph = BookmarkGraph::for_testing(vec!["feat<xss>".into()], BTreeMap::new());
+
+        let mut crs = ChangeRequests::default();
+        crs.set(
+            "feat<xss>".to_string(),
+            ForgeMeta {
+                forge: Some(ForgeOneof::Github(GitHubMeta {
+                    number: 1,
+                    source_branch: "feat<xss>".into(),
+                    target_branch: "main".into(),
+                    source_repo: "owner/repo".into(),
+                    target_repo: "owner/repo".into(),
+                    graphql_id: String::new(),
+                    comment_id: None,
+                })),
+            },
+        );
+
+        let comment = Comment::new(&bookmark, &graph, &crs);
+        let output = comment.to_string().unwrap();
+
+        assert!(output.contains("feat&lt;xss&gt;"));
+        assert!(!output.contains("feat<xss>"));
+    }
+
+    // -- Error tests --
+
+    #[test]
     fn missing_change_request_for_root_returns_error() {
-        // root_bookmarks references "feat-a" but it's not in change_requests
         let bookmark = make_bookmark("feat-a");
         let graph = BookmarkGraph::for_testing(vec!["feat-a".into()], BTreeMap::new());
         let crs = ChangeRequests::default();
@@ -241,7 +680,6 @@ mod tests {
         let bookmark = make_bookmark("feat-a");
         let graph = BookmarkGraph::for_testing(vec!["feat-a".into()], BTreeMap::new());
 
-        // ForgeMeta with no forge variant → target_branch() returns None
         let mut crs = ChangeRequests::default();
         crs.set("feat-a".to_string(), ForgeMeta { forge: None });
 
@@ -251,8 +689,10 @@ mod tests {
         assert!(matches!(err, CommentError::NoBaseBranchFound));
     }
 
+    // -- Footer test --
+
     #[test]
-    fn comment_includes_header_and_footer() {
+    fn includes_jj_spice_footer() {
         let bookmark = make_bookmark("feat");
         let graph = BookmarkGraph::for_testing(vec!["feat".into()], BTreeMap::new());
         let crs = make_change_requests(vec![("feat", 42, "main")]);
@@ -260,29 +700,9 @@ mod tests {
         let comment = Comment::new(&bookmark, &graph, &crs);
         let output = comment.to_string().unwrap();
 
-        assert!(output.starts_with("This change belongs to the following stack:\n"));
+        assert!(output.contains("<pre>"));
         assert!(output.ends_with(
-            "Change managed by [jj-spice](https://github.com/alejoborbo/jj-spice).</sub>"
+            "Change managed by <a href=\"https://github.com/alejoborbo/jj-spice\">jj-spice</a>.</sub>"
         ));
-    }
-
-    #[test]
-    fn forking_stack_shows_both_branches() {
-        // root -> child-a, root -> child-b (both target "root")
-        let current = make_bookmark("root");
-        let graph = BookmarkGraph::for_testing(vec!["root".into()], BTreeMap::new());
-        let crs = make_change_requests(vec![
-            ("root", 1, "main"),
-            ("child-a", 2, "root"),
-            ("child-b", 3, "root"),
-        ]);
-
-        let comment = Comment::new(&current, &graph, &crs);
-        let output = comment.to_string().unwrap();
-
-        assert!(output.contains("- #1 👈 you are here!\n"));
-        // Both children at depth 1
-        assert!(output.contains("  - #2\n"));
-        assert!(output.contains("  - #3\n"));
     }
 }


### PR DESCRIPTION
jj allows to have a full graph and not only a tree for its bookmark organization, the previous view was not adapted for showing a graph. Rewrite change request comments from a flat indented list to an ASCII-art graph inside `<pre>` with clickable links, emoji status badges, and trunk node. Inspired from the style of `stack log` command.

Also refactor `CommentNode` to be forge-agnostic: extract CR label and fallback URL once per forge variant so graph rendering is shared between GitHub PRs (#N) and GitLab MRs (!N).