### PR TITLE
feat(submit): add --auto-accept argument (#41)

### DIFF
--- a/cli/src/commands/cli.rs
+++ b/cli/src/commands/cli.rs
@@ -77,6 +77,12 @@ pub struct SubmitArgs {
     /// By default, jj-spice will only track change requests that are open, or in draft.
     #[arg(long, default_value_t = false)]
     pub allow_inactive: bool,
+    /// Auto accepts pushing untracked changes.
+    ///
+    /// By default, the user will be prompted if some changes are untracked.
+    /// If the --auto-accept flag is passed, untracked changes will be automatically pushed.
+    #[arg(long)]
+    pub auto_accept: bool,
 }
 
 /// Arguments for `jj-spice stack sync`.

--- a/cli/src/commands/stack_submit.rs
+++ b/cli/src/commands/stack_submit.rs
@@ -47,7 +47,13 @@ pub async fn run(
         let ascendants = bookmark_node.ascendants();
 
         // Check for untracked changes in the bookmark and push them if the user agrees.
-        check_untracked_changes(&env.ui, env, bookmark, bookmark_node.commits())?;
+        check_untracked_changes(
+            &env.ui,
+            env,
+            bookmark,
+            bookmark_node.commits(),
+            args.auto_accept,
+        )?;
 
         // If the change request already exists, retarget if needed.
         let existing = get_existing_change_request(
@@ -210,6 +216,7 @@ fn check_untracked_changes(
     env: &SpiceEnv,
     bookmark: &Bookmark,
     commit_ids: &[CommitId],
+    auto_accept: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let remote = env.get_default_remote();
     let local_remote_target = bookmark.remote_ref(&remote).ok_or_else(|| {
@@ -231,9 +238,23 @@ fn check_untracked_changes(
 
             writeln!(
                 ui.warning_default(),
-                "Untracked changes have been detected. Do you want to push them?",
+                "Untracked changes have been detected.",
             )?;
-            if ui.prompt_yes_no("Push changes?", Some(true))? {
+            let should_push = if auto_accept {
+                writeln!(
+                    ui.stdout_formatter(),
+                    "Auto accept is enabled, pushing commits to {}",
+                    remote.as_str(),
+                )?;
+                true
+            } else {
+                ui.prompt_yes_no(
+                    &format!("Do you want to push them to {}?", remote.as_str(),),
+                    Some(true),
+                )?
+            };
+
+            if should_push {
                 push_bookmarks(env, &remote, bookmark, push_update, commits_to_sign)?;
                 writeln!(
                     ui.stdout_formatter(),


### PR DESCRIPTION
Add the `--auto-accept` flag to automatically push untracked changes in `stack submit`.

If the flag is not passed, the user is prompted to confirm the push.
