### PR TITLE
fix: resolve bookmark commit from remote refs when local target is absent

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -21,6 +21,7 @@ use cli::{Cli, SpiceCommand, StackCommand, UtilCommand};
 use env::SpiceEnv;
 use jj_cli::cli_util::RevisionArg;
 use jj_lib::repo::Repo as _;
+use jj_spice_lib::bookmark::resolve_commit_id;
 use jj_spice_lib::forge::detect::detect_forges;
 
 /// Dispatch to the appropriate command.
@@ -79,6 +80,14 @@ pub(crate) fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                         .map_err(|e| format!("failed to resolve @: {e}"))?;
                     rt.block_on(async {
                         let detection = detect_forges(env.repo.store(), env.config())?;
+
+                        let trunk_name = env
+                            .repo
+                            .view()
+                            .bookmarks()
+                            .find(|(_, target)| resolve_commit_id(target) == Some(&trunk))
+                            .map(|(name, _)| name.as_str().to_string())
+                            .ok_or("no bookmark found at trunk commit")?;
 
                         let (forge, source_repo) = env.resolve_forge(detection.forges)?;
 

--- a/cli/src/commands/stack_log.rs
+++ b/cli/src/commands/stack_log.rs
@@ -11,6 +11,7 @@ use jj_lib::repo::Repo;
 
 use crate::commands::env::{OutputMode, SpiceEnv};
 use jj_spice_lib::bookmark::graph::{BookmarkGraph, BookmarkNode};
+use jj_spice_lib::bookmark::resolve_commit_id;
 use jj_spice_lib::forge::detect::{DetectionResult, detect_forges};
 use jj_spice_lib::forge::{ChangeRequest, ChangeStatus, Forge};
 use jj_spice_lib::protos::change_request::ForgeMeta;
@@ -183,12 +184,12 @@ fn find_stale_roots(
 
 /// Find the bookmark name pointing at the trunk commit.
 ///
-/// Scans all bookmarks in the repo for one whose local target matches
-/// `trunk_id`. Returns `None` if no bookmark is found (shouldn't happen
-/// in practice since `trunk()` resolves from a bookmark).
+/// Scans all bookmarks in the repo for one whose commit (local or remote)
+/// matches `trunk_id`. Returns `None` if no bookmark is found (shouldn't
+/// happen in practice since `trunk()` resolves from a bookmark).
 fn resolve_trunk_bookmark_name(env: &SpiceEnv, trunk_id: &CommitId) -> Option<String> {
     env.repo.view().bookmarks().find_map(|(name, target)| {
-        if target.local_target.as_normal() == Some(trunk_id) {
+        if resolve_commit_id(&target) == Some(trunk_id) {
             Some(name.as_str().to_string())
         } else {
             None

--- a/lib/src/bookmark.rs
+++ b/lib/src/bookmark.rs
@@ -1,9 +1,27 @@
+use jj_lib::backend::CommitId;
 use jj_lib::op_store::LocalRemoteRefTarget;
 use jj_lib::ref_name::RemoteNameBuf;
 use jj_lib::refs::LocalAndRemoteRef;
 
 /// DAG of bookmarks between trunk and head for stack operations.
 pub mod graph;
+
+/// Resolve the commit a bookmark points to, preferring the local target but
+/// falling back to remote refs.
+///
+/// jj's `trunk()` revset resolves via `remote_bookmarks()` so a local
+/// bookmark is never required.  This helper follows the same semantics:
+/// when the local target is absent it returns the first available remote
+/// ref's commit instead.
+pub fn resolve_commit_id<'a>(target: &'a LocalRemoteRefTarget<'_>) -> Option<&'a CommitId> {
+    if let Some(id) = target.local_target.as_normal() {
+        return Some(id);
+    }
+    target
+        .remote_refs
+        .iter()
+        .find_map(|(_, remote_ref)| remote_ref.target.as_normal())
+}
 
 /// A remote that tracks this bookmark.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -112,9 +130,24 @@ mod tests {
         }
     }
 
+    fn commit_id(byte: u8) -> CommitId {
+        CommitId::new(vec![byte])
+    }
+
     fn make_remote_ref(tracked: bool) -> RemoteRef {
         RemoteRef {
             target: RefTarget::absent(),
+            state: if tracked {
+                RemoteRefState::Tracked
+            } else {
+                RemoteRefState::New
+            },
+        }
+    }
+
+    fn make_remote_ref_at(id: &CommitId, tracked: bool) -> RemoteRef {
+        RemoteRef {
+            target: RefTarget::normal(id.clone()),
             state: if tracked {
                 RemoteRefState::Tracked
             } else {
@@ -238,5 +271,73 @@ mod tests {
         set.insert(a);
         set.insert(b);
         assert_eq!(set.len(), 1);
+    }
+
+    // -- resolve_commit_id tests --
+
+    #[test]
+    fn resolve_commit_id_returns_local_target_when_present() {
+        let id = commit_id(1);
+        let local = RefTarget::normal(id.clone());
+        let target = LocalRemoteRefTarget {
+            local_target: &local,
+            remote_refs: vec![],
+        };
+        assert_eq!(resolve_commit_id(&target), Some(&id));
+    }
+
+    #[test]
+    fn resolve_commit_id_falls_back_to_remote_ref() {
+        let id = commit_id(2);
+        let remote = make_remote_ref_at(&id, true);
+        let target = LocalRemoteRefTarget {
+            local_target: RefTarget::absent_ref(),
+            remote_refs: vec![(RemoteName::new("origin"), &remote)],
+        };
+        assert_eq!(resolve_commit_id(&target), Some(&id));
+    }
+
+    #[test]
+    fn resolve_commit_id_falls_back_to_untracked_remote_ref() {
+        let id = commit_id(3);
+        let remote = make_remote_ref_at(&id, false);
+        let target = LocalRemoteRefTarget {
+            local_target: RefTarget::absent_ref(),
+            remote_refs: vec![(RemoteName::new("origin"), &remote)],
+        };
+        assert_eq!(resolve_commit_id(&target), Some(&id));
+    }
+
+    #[test]
+    fn resolve_commit_id_prefers_local_over_remote() {
+        let local_id = commit_id(10);
+        let remote_id = commit_id(20);
+        let local = RefTarget::normal(local_id.clone());
+        let remote = make_remote_ref_at(&remote_id, true);
+        let target = LocalRemoteRefTarget {
+            local_target: &local,
+            remote_refs: vec![(RemoteName::new("origin"), &remote)],
+        };
+        assert_eq!(resolve_commit_id(&target), Some(&local_id));
+    }
+
+    #[test]
+    fn resolve_commit_id_returns_none_when_all_absent() {
+        assert_eq!(resolve_commit_id(&absent_target()), None);
+    }
+
+    #[test]
+    fn resolve_commit_id_skips_absent_remote_refs() {
+        let id = commit_id(5);
+        let absent_remote = make_remote_ref(true); // absent target
+        let present_remote = make_remote_ref_at(&id, true);
+        let target = LocalRemoteRefTarget {
+            local_target: RefTarget::absent_ref(),
+            remote_refs: vec![
+                (RemoteName::new("origin"), &absent_remote),
+                (RemoteName::new("upstream"), &present_remote),
+            ],
+        };
+        assert_eq!(resolve_commit_id(&target), Some(&id));
     }
 }

--- a/lib/src/bookmark/graph.rs
+++ b/lib/src/bookmark/graph.rs
@@ -13,7 +13,7 @@ use jj_lib::{
 };
 use thiserror::Error;
 
-use super::Bookmark;
+use super::{Bookmark, resolve_commit_id};
 
 /// Nodes keyed by bookmark name and their outgoing edges, as built by
 /// [`BookmarkGraph::build_bookmark_graph`].
@@ -300,15 +300,14 @@ impl<'a> BookmarkGraph<'a> {
         repo.view()
             .bookmarks()
             .filter_map(|(ref_name, ref_target)| {
-                // Ignore unresolved/conflicted commits
-                // TODO: Improve this behavior
-                if let Some(commit_id) = ref_target.local_target.as_normal() {
-                    return Some((
-                        commit_id.to_owned(),
-                        Arc::new(Bookmark::new(ref_name.as_str().to_string(), ref_target)),
-                    ));
-                }
-                None
+                // Resolve via local target first, falling back to remote refs.
+                // This handles bookmarks that only exist as remote-tracking
+                // refs (e.g. main@origin with no local main).
+                let commit_id = resolve_commit_id(&ref_target)?;
+                Some((
+                    commit_id.to_owned(),
+                    Arc::new(Bookmark::new(ref_name.as_str().to_string(), ref_target)),
+                ))
             })
             .into_group_map()
     }


### PR DESCRIPTION
jj's trunk() revset resolves via remote_bookmarks(), so a local
bookmark is not required. Fix the reverse lookup (commit -> bookmark
name) and bookmark graph construction to also consider remote refs,
matching jj's own resolution semantics.