### PR TITLE
feat(submit): add --draft and --no-draft args (#58)

### DIFF
--- a/cli/src/commands/cli.rs
+++ b/cli/src/commands/cli.rs
@@ -88,6 +88,16 @@ pub struct SubmitArgs {
     /// When a bookmark has no remote, allow them to be tracked directly when submitting changes.
     #[arg(long)]
     pub auto_track_bookmarks: bool,
+    /// Set the change request in draft state.
+    ///
+    /// By default, the user is prompt to choose the CR state.
+    #[arg(long, conflicts_with = "no_draft")]
+    pub draft: bool,
+    /// Set the change request in non-draft state.
+    ///
+    /// By default, the user is prompt to choose the CR state.
+    #[arg(long, conflicts_with = "draft")]
+    pub no_draft: bool,
 }
 
 /// Arguments for `jj-spice stack sync`.

--- a/cli/src/commands/stack_submit.rs
+++ b/cli/src/commands/stack_submit.rs
@@ -149,7 +149,13 @@ pub async fn run(
             |input| -> Result<String, &'static str> { Ok(input.to_string()) },
         )?;
         let description = text_editor.edit_str(&suggested_body, Some(".md"))?;
-        let is_draft = env.ui.prompt_yes_no("Draft?", Some(false))?;
+        let is_draft = if args.draft {
+            true
+        } else if args.no_draft {
+            false
+        } else {
+            env.ui.prompt_yes_no("Draft?", Some(false))?
+        };
 
         let params = CreateParams {
             source_branch: bookmark.name(),


### PR DESCRIPTION
This PR adds the following mutually exclusive arguments to `stack submit`:
* `--draft`: set all the newly created change requests as draft
* `--no-draft`: set all the newly created change requests as not draft

Closes #58 
