### PR TITLE
refactor(submit): display hint instead of warning when changes are

### DIFF
--- a/cli/src/commands/stack_submit.rs
+++ b/cli/src/commands/stack_submit.rs
@@ -122,7 +122,7 @@ pub async fn run(
                 }
                 _ => {
                     writeln!(
-                        env.ui.warning_default(),
+                        env.ui.hint_no_heading(),
                         "{}: already tracked, skipping",
                         meta.name,
                     )?;
@@ -641,7 +641,7 @@ async fn get_existing_change_request(
         1 => Ok(Some(metas.into_iter().next().unwrap())),
         _ => {
             writeln!(
-                ui.warning_default(),
+                ui.hint_no_heading(),
                 "{bookmark}: found {} change requests on the forge",
                 metas.len()
             )?;


### PR DESCRIPTION
When changes are untracked (or even bookmarks), a warning was emitted. This has been changed to simply show a message without being a warning.
