### PR TITLE
docs: add configuration reference for TOML settings

### DIFF
--- a/cli/src/commands/cli.rs
+++ b/cli/src/commands/cli.rs
@@ -1,5 +1,8 @@
+use std::fmt::Write as _;
+
+use clap::builder::StyledStr;
 use clap::builder::Styles;
-use clap::builder::styling::AnsiColor;
+use clap::builder::styling::{AnsiColor, Style as AnsiStyle};
 use clap::{Args, Command, Parser, Subcommand};
 use jj_cli::cli_util::GlobalArgs;
 
@@ -12,6 +15,34 @@ const STYLES: Styles = Styles::styled()
     .usage(AnsiColor::Yellow.on_default().bold())
     .literal(AnsiColor::Green.on_default().bold())
     .placeholder(AnsiColor::Green.on_default());
+
+/// Style for section headers in after-help text (matches `STYLES` header).
+const HEADER_STYLE: AnsiStyle = AnsiColor::Yellow.on_default().bold();
+/// Style for config key literals in after-help text (matches `STYLES` literal).
+const LITERAL_STYLE: AnsiStyle = AnsiColor::Green.on_default().bold();
+
+/// Build a styled "Configuration:" after-help section for `--help` output.
+///
+/// Matches the indentation and layout of clap's built-in "Options:" section:
+/// 6-space indent for key names, 10-space indent for description lines,
+/// blank line between entries. ANSI codes are stripped automatically by
+/// clap's output pipeline when colour is disabled.
+fn config_after_help(entries: &[(&str, &str)]) -> StyledStr {
+    let mut out = StyledStr::new();
+    writeln!(out, "{HEADER_STYLE}Configuration:{HEADER_STYLE:#}").unwrap();
+
+    for (i, &(key, desc)) in entries.iter().enumerate() {
+        writeln!(out, "      {LITERAL_STYLE}{key}{LITERAL_STYLE:#}").unwrap();
+        for line in desc.lines() {
+            writeln!(out, "          {line}").unwrap();
+        }
+        // Blank line between entries, but not after the last one.
+        if i + 1 < entries.len() {
+            writeln!(out).unwrap();
+        }
+    }
+    out
+}
 
 /// jj-spice: forge integration for jj.
 #[derive(Parser, Clone, Debug)]
@@ -35,6 +66,11 @@ pub enum SpiceCommand {
 
 /// Arguments for the `stack` subcommand group.
 #[derive(Args, Clone, Debug)]
+#[command(after_long_help = config_after_help(&[
+    ("spice.output",                 "Terminal output fidelity: \"modern\" (default) or \"classic\""),
+    ("spice.upstream-remote",        "Override the upstream remote name for fork workflows (string)"),
+    ("spice.forges.<hostname>.type", "Forge type for a custom hostname: \"github\" or \"gitlab\""),
+]))]
 pub struct StackArgs {
     /// The stack operation to perform.
     #[command(subcommand)]
@@ -65,6 +101,10 @@ pub enum StackCommand {
 
 /// Arguments for `jj-spice stack log`.
 #[derive(Args, Clone, Debug)]
+#[command(after_long_help = config_after_help(&[
+    ("spice.output", "Terminal output fidelity: \"modern\" (default) or \"classic\".\n\
+                      Controls status badge rendering and link format."),
+]))]
 pub struct LogArgs {
     /// Which revisions to show bookmarks for.
     ///
@@ -79,6 +119,11 @@ pub struct LogArgs {
 
 /// Arguments for `jj-spice stack submit`.
 #[derive(Args, Clone, Debug)]
+#[command(after_long_help = config_after_help(&[
+    ("spice.auto-accept-changes", "Skip the push-confirmation prompt (bool, default: false).\n\
+                                   Equivalent to --auto-accept."),
+    ("spice.auto-clean",          "Remove closed CRs from tracking automatically (bool, default: true)."),
+]))]
 pub struct SubmitArgs {
     /// Allow intactive (merged and closed) change requests to be tracked.
     ///
@@ -92,6 +137,8 @@ pub struct SubmitArgs {
     ///
     /// By default, the user will be prompted if some changes are untracked.
     /// If the --auto-accept flag is passed, untracked changes will be automatically pushed.
+    ///
+    /// [config: `spice.auto-accept-changes`]
     #[arg(long)]
     pub auto_accept: bool,
     /// Auto track bookmarks
@@ -113,6 +160,9 @@ pub struct SubmitArgs {
 
 /// Arguments for `jj-spice stack sync`.
 #[derive(Args, Clone, Debug)]
+#[command(after_long_help = config_after_help(&[
+    ("spice.auto-clean", "Remove stale/inactive CRs from tracking automatically (bool, default: true)."),
+]))]
 pub struct SyncArgs {
     /// Re-discover change requests even for bookmarks that are already tracked.
     #[arg(long)]

--- a/docs/references/configuration.md
+++ b/docs/references/configuration.md
@@ -1,0 +1,107 @@
+# Configuration reference
+
+`jj-spice` is configured through the standard jj configuration stack. All
+settings live under the `[spice]` table and can be set at any level of the
+hierarchy (user, repo, or workspace) using the regular jj config files or the
+`--config` CLI flag.
+
+For details on how jj resolves its configuration, see the
+[jj configuration docs](https://jj-vcs.github.io/jj/latest/config/).
+
+## Quick reference
+
+| Key | Type | Default | Related CLI flag |
+|-----|------|---------|-----------------|
+| [`spice.output`](#spiceoutput) | `"modern"` \| `"classic"` | `"modern"` | -- |
+| [`spice.auto-accept-changes`](#spiceauto-accept-changes) | `bool` | `false` | `--auto-accept` |
+| [`spice.auto-clean`](#spiceauto-clean) | `bool` | `true` | -- |
+| [`spice.upstream-remote`](#spiceupstream-remote) | `string` | auto-detected | -- |
+| [`spice.forges.<hostname>.type`](#spiceforgeshostnametype) | `"github"` \| `"gitlab"` | auto-detected | -- |
+
+## `spice.output`
+
+Terminal output fidelity.
+
+- **`"modern"`** (default) -- Nerd Font Powerline glyphs for status badges,
+  OSC 8 terminal hyperlinks. Requires a
+  [Nerd Font](https://www.nerdfonts.com/).
+- **`"classic"`** -- ASCII brackets `[Status]` with foreground-only colors,
+  plain-text URL fallbacks. Safe for any terminal.
+
+```toml
+[spice]
+output = "classic"
+```
+
+**Affects:** `stack log`, `stack submit`, `stack sync`.
+
+## `spice.auto-accept-changes`
+
+When `true`, untracked changes are pushed automatically during `stack submit`
+without prompting.
+
+When unset or `false`, the user is prompted before pushing.
+
+Equivalent to passing `--auto-accept` on the command line. The config value
+takes precedence over the flag when set.
+
+```toml
+[spice]
+auto-accept-changes = true
+```
+
+**Affects:** `stack submit`.
+
+## `spice.auto-clean`
+
+When `true` (the default), inactive change requests (closed or merged on the
+forge) are automatically removed from local tracking during `stack submit` and
+`stack sync`.
+
+Set to `false` to keep inactive entries until they are removed manually with
+`stack clean` or `stack untrack`.
+
+```toml
+[spice]
+auto-clean = false
+```
+
+**Affects:** `stack submit`, `stack sync`.
+
+## `spice.upstream-remote`
+
+Override the upstream remote name used for fork workflows.
+
+In a fork setup, `jj-spice` pushes branches to the *push remote*
+(`git.push`, defaulting to `"origin"`) and creates change requests against
+the *upstream remote*. By default, a remote named `"upstream"` is used when
+it exists. Set this key to use a different name.
+
+```toml
+[spice]
+upstream-remote = "upstream"
+```
+
+**Affects:** all `stack` subcommands.
+
+## `spice.forges.<hostname>.type`
+
+Register a custom hostname as a specific forge type.
+
+`jj-spice` automatically recognises `github.com` and `gitlab.com`. For
+self-hosted instances (GitHub Enterprise, self-managed GitLab, etc.),
+map the hostname to a forge type so that `jj-spice` can interact with its
+API.
+
+This setting is typically written to the *repo-level* config by `stack sync`
+when it encounters an unknown hostname and prompts the user to select a forge
+type. It can also be set manually.
+
+```toml
+[spice.forges."git.corp.example.com"]
+type = "github"
+```
+
+Accepted values: `"github"`, `"gitlab"`.
+
+**Affects:** all `stack` subcommands.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,3 +10,5 @@ nav:
   - Home: index.md
   - Getting Started:
     - Installation and Setup: installation-and-setup.md
+  - Reference:
+    - Configuration: references/configuration.md


### PR DESCRIPTION
Add documentation for all `spice.*` config keys:

- **`docs/references/configuration.md`**: new reference page listing every
  key with its type, default, related CLI flag, and example TOML snippet.
  Added to the mkdocs nav under *Reference > Configuration*.

- **`cli/src/commands/cli.rs`**: enrich `--help` output with config
  information. Each subcommand that reads config now has an `after_long_help`
  *Configuration* section listing the relevant keys. The `--auto-accept` flag
  on `stack submit` is annotated with its config equivalent
  (`spice.auto-accept-changes`).