### PR TITLE
chore: bump to v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2559,7 +2559,7 @@ dependencies = [
 
 [[package]]
 name = "jj-spice-cli"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "clap",
@@ -2577,7 +2577,7 @@ dependencies = [
 
 [[package]]
 name = "jj-spice-lib"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "const_format",
  "gix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,12 +3,12 @@ resolver = "3"
 members = ["cli", "lib", "lib/gen-protos"]
 
 [workspace.package]
-version = "0.2.2"
+version = "0.3.0"
 edition = "2024"
 license = "Apache-2.0"
 
 [workspace.dependencies]
-jj-spice-lib = { path = "lib", version = "0.2.2" }
+jj-spice-lib = { path = "lib", version = "0.3.0" }
 
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 clap = { version = "4.5.60", features = ["derive"] }


### PR DESCRIPTION
Bump to `v0.3.0`