### PR TITLE
docs: improve search engine indexation and ranking for documentation site

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,5 +154,5 @@ jobs:
           path: ~/.cache
           restore-keys: |
             mkdocs-material-
-      - run: pip install mkdocs-material
+      - run: pip install mkdocs-material "mkdocs-material[imaging]"
       - run: mkdocs gh-deploy --force

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  jj-spice automates stacked change requests for Jujutsu (jj) repositories.
+  Submit, sync, and visualize dependent PR chains on GitHub and GitLab.
+---
+
 # jj-spice
 
 Submit, sync, and track stacked change requests in your [jj (Jujutsu)](https://github.com/jj-vcs/jj) repository without the busywork.
@@ -9,9 +15,21 @@ PRs that depend on each other. `jj-spice` automates the tedious parts — creati
 the PRs, keeping their base branches in sync, and tracking their status.
 
 `jj-spice` allows you to:
+
 - Submit a stack of change requests
 - Sync the current stack with a remote repository
 - Visualize the stack and its review status
 
-The following version control systems are supported:
+The following forges are supported:
+
 - [GitHub](https://github.com)
+- [GitLab](https://gitlab.com)
+
+## Demo
+
+[![asciicast](https://asciinema.org/a/kBv6aeMHxa0KaMt3.svg)](https://asciinema.org/a/kBv6aeMHxa0KaMt3)
+
+## Getting started
+
+Install `jj-spice` and set up shell completion and jj aliases in the
+[Installation and Setup](installation-and-setup.md) guide.

--- a/docs/installation-and-setup.md
+++ b/docs/installation-and-setup.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Install jj-spice via Homebrew, Cargo, Scoop, Winget, or from source.
+  Configure terminal output, shell completion, and jj aliases.
+---
+
 # Installation and setup
 
 ## Installation

--- a/docs/references/configuration.md
+++ b/docs/references/configuration.md
@@ -1,3 +1,9 @@
+---
+description: >-
+  Complete reference for jj-spice configuration — output mode,
+  auto-accept, auto-clean, upstream remote, and custom forge hostnames.
+---
+
 # Configuration reference
 
 `jj-spice` is configured through the standard jj configuration stack. All

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://alejoborbo.github.io/jj-spice/sitemap.xml

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,14 +1,38 @@
 site_name: jj-spice
 site_url: https://alejoborbo.github.io/jj-spice
+site_description: >-
+  Submit, sync, and track stacked change requests in your Jujutsu (jj)
+  repository. Create dependent PR chains on GitHub and GitLab from the
+  command line.
+repo_url: https://github.com/alejoborbo/jj-spice
+repo_name: alejoborbo/jj-spice
+
 theme:
   name: material
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.sections
+    - navigation.top
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+
+plugins:
+  - search
+  - social
+
 extra:
   analytics:
     provider: google
     property: G-WFM9GL0JQ4
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/alejoborbo/jj-spice
+
 nav:
   - Home: index.md
   - Getting Started:
-    - Installation and Setup: installation-and-setup.md
+      - Installation and Setup: installation-and-setup.md
   - Reference:
-    - Configuration: references/configuration.md
+      - Configuration: references/configuration.md


### PR DESCRIPTION
The documentation site lacks meta descriptions, Open Graph tags, and a
robots.txt — search engines have to guess page summaries, and shared links
on social media render without previews.

Add site-wide and per-page meta descriptions, enable the social plugin for
automatic OG card generation, expose the repository link in the site header,
and point crawlers to the sitemap. Also fix the homepage that was missing
GitLab from the supported forges list.