### PR TITLE
feat: sync fork's trunk branch with upstream during `stack sync`

### DIFF
--- a/cli/src/commands/cli.rs
+++ b/cli/src/commands/cli.rs
@@ -162,6 +162,8 @@ pub struct SubmitArgs {
 #[derive(Args, Clone, Debug)]
 #[command(after_long_help = config_after_help(&[
     ("spice.auto-clean", "Remove stale/inactive CRs from tracking automatically (bool, default: true)."),
+    ("spice.sync-fork",  "Sync the fork's trunk with upstream during `stack sync` (bool, default: false).\n\
+                          Equivalent to --sync-fork."),
 ]))]
 pub struct SyncArgs {
     /// Re-discover change requests even for bookmarks that are already tracked.
@@ -180,6 +182,23 @@ pub struct SyncArgs {
     /// By default, latest version of the trunk is fetched, but the stack is not rebased.
     #[arg(long)]
     pub restack: bool,
+    /// Sync the fork's trunk branch with upstream.
+    ///
+    /// In fork mode, syncs the fork's default branch with upstream via
+    /// the forge API (GitHub) or a local push (GitLab / other forges)
+    /// so the fork stays up-to-date.
+    ///
+    /// Use `--sync-fork` or `--sync-fork=true` to enable,
+    /// `--sync-fork=false` to disable (overrides config).
+    ///
+    /// [config: `spice.sync-fork`]
+    #[arg(
+        long,
+        num_args(0..=1),
+        require_equals = true,
+        default_missing_value = "true",
+    )]
+    pub sync_fork: Option<bool>,
 }
 
 /// Arguments for `jj-spice stack untrack`.
@@ -356,6 +375,50 @@ mod tests {
             SpiceCommand::Stack(StackArgs {
                 command: StackCommand::Sync(args),
             }) => assert!(!args.force),
+            _ => panic!("expected Sync"),
+        }
+    }
+
+    #[test]
+    fn parse_stack_sync_absent_sync_fork_is_none() {
+        let cli = Cli::try_parse_from(["jj-spice", "stack", "sync"]).unwrap();
+        match cli.command {
+            SpiceCommand::Stack(StackArgs {
+                command: StackCommand::Sync(args),
+            }) => assert_eq!(args.sync_fork, None),
+            _ => panic!("expected Sync"),
+        }
+    }
+
+    #[test]
+    fn parse_stack_sync_bare_sync_fork_is_true() {
+        let cli = Cli::try_parse_from(["jj-spice", "stack", "sync", "--sync-fork"]).unwrap();
+        match cli.command {
+            SpiceCommand::Stack(StackArgs {
+                command: StackCommand::Sync(args),
+            }) => assert_eq!(args.sync_fork, Some(true)),
+            _ => panic!("expected Sync"),
+        }
+    }
+
+    #[test]
+    fn parse_stack_sync_sync_fork_eq_true() {
+        let cli = Cli::try_parse_from(["jj-spice", "stack", "sync", "--sync-fork=true"]).unwrap();
+        match cli.command {
+            SpiceCommand::Stack(StackArgs {
+                command: StackCommand::Sync(args),
+            }) => assert_eq!(args.sync_fork, Some(true)),
+            _ => panic!("expected Sync"),
+        }
+    }
+
+    #[test]
+    fn parse_stack_sync_sync_fork_eq_false() {
+        let cli = Cli::try_parse_from(["jj-spice", "stack", "sync", "--sync-fork=false"]).unwrap();
+        match cli.command {
+            SpiceCommand::Stack(StackArgs {
+                command: StackCommand::Sync(args),
+            }) => assert_eq!(args.sync_fork, Some(false)),
             _ => panic!("expected Sync"),
         }
     }

--- a/cli/src/commands/stack_sync.rs
+++ b/cli/src/commands/stack_sync.rs
@@ -2,12 +2,16 @@ use std::collections::{HashMap, HashSet};
 use std::io::Write;
 use std::sync::Arc;
 
-use jj_cli::git_util::GitSubprocessUi;
+use jj_cli::git_util::{GitSubprocessUi, print_push_stats};
 use jj_cli::ui::Ui;
 use jj_lib::backend::CommitId;
 use jj_lib::config::{ConfigFile, ConfigSource};
-use jj_lib::git::{GitFetch, GitFetchRefExpression, GitImportOptions, expand_fetch_refspecs};
-use jj_lib::ref_name::{RefName, RemoteName};
+use jj_lib::git::{
+    self, GitBranchPushTargets, GitFetch, GitFetchRefExpression, GitImportOptions,
+    expand_fetch_refspecs,
+};
+use jj_lib::ref_name::{RefName, RefNameBuf, RemoteName};
+use jj_lib::refs::classify_bookmark_push_action;
 use jj_lib::repo::{ReadonlyRepo, Repo};
 use jj_lib::revset::ResolvedRevsetExpression;
 use jj_lib::rewrite::{
@@ -64,10 +68,29 @@ pub async fn run(
     // Prompt for unmatched remotes (grouped by hostname).
     resolve_unmatched_remotes(env, &unmatched, &mut forges)?;
 
+    // Resolve fork sync: --sync-fork[=bool] > config > false.
+    let sync_fork_enabled = args.sync_fork.unwrap_or_else(|| {
+        env.config()
+            .get::<bool>(["spice", "sync-fork"])
+            .unwrap_or(false)
+    });
+
+    let fork_synced = if sync_fork_enabled {
+        sync_fork_server_side(env, &forges, trunk_name).await?
+    } else {
+        false
+    };
+
     // Fetch the latest remote changes for the trunk branch.
     // The returned repo reflects the fetched state so subsequent operations
     // see the up-to-date trunk.
     let repo_after_fetch = fetch_trunk(env, trunk_name)?;
+
+    // If fork sync is enabled but the forge did not support server-side
+    // sync, push the freshly-fetched trunk to the fork remote instead.
+    if sync_fork_enabled && !fork_synced && env.is_fork_mode() {
+        push_trunk_to_fork(env, &repo_after_fetch, trunk_name)?;
+    }
 
     // Re-resolve trunk from the updated view — the bookmark may have advanced
     // after the fetch (e.g. new merge commits on main).
@@ -335,6 +358,118 @@ fn fetch_trunk(
     }
 
     Ok(tx.commit("fetch trunk")?)
+}
+
+/// Try to sync the fork's trunk branch via the forge API (server-side).
+///
+/// In fork mode, the forge attached to the push remote (the fork) is asked
+/// to fast-forward its branch to match upstream. Returns `true` when the
+/// server-side sync succeeded (or the branch was already up-to-date),
+/// `false` when no forge was found for the push remote or the forge does
+/// not support server-side syncing.
+async fn sync_fork_server_side(
+    env: &SpiceEnv,
+    forges: &HashMap<String, Box<dyn Forge>>,
+    trunk_name: &str,
+) -> Result<bool, Box<dyn std::error::Error>> {
+    if !env.is_fork_mode() {
+        return Ok(false);
+    }
+
+    let push_remote = env.get_default_remote();
+    let fork_forge = match forges.get(push_remote.as_str()) {
+        Some(f) => f,
+        None => return Ok(false),
+    };
+
+    match fork_forge.sync_fork(trunk_name).await {
+        Ok(true) => {
+            writeln!(
+                env.ui.status(),
+                "Fork synced with upstream (server-side, {})",
+                push_remote.as_str(),
+            )?;
+            Ok(true)
+        }
+        Ok(false) => {
+            // Forge does not support server-side sync — caller will fall back.
+            Ok(false)
+        }
+        Err(e) => {
+            writeln!(
+                env.ui.warning_default(),
+                "Could not sync fork via API: {e} (will push locally instead)"
+            )?;
+            Ok(false)
+        }
+    }
+}
+
+/// Push the local trunk to the fork remote so it stays up-to-date.
+///
+/// Used as a fallback when the forge does not support server-side fork
+/// syncing (e.g. GitLab). The push is a fast-forward of the fork's trunk
+/// bookmark to match the locally-fetched upstream state.
+fn push_trunk_to_fork(
+    env: &SpiceEnv,
+    repo: &Arc<ReadonlyRepo>,
+    trunk_name: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use jj_lib::ref_name::RemoteRefSymbol;
+    use jj_lib::refs::LocalAndRemoteRef;
+
+    let push_remote = env.get_default_remote();
+
+    let ref_name = RefName::new(trunk_name);
+    let local_target = repo.view().get_local_bookmark(ref_name);
+    let remote_ref = repo.view().get_remote_bookmark(RemoteRefSymbol {
+        name: ref_name,
+        remote: &push_remote,
+    });
+    let action = classify_bookmark_push_action(LocalAndRemoteRef {
+        local_target,
+        remote_ref,
+    });
+
+    let update = match action {
+        jj_lib::refs::BookmarkPushAction::Update(update) => update,
+        // Already up-to-date or would need force — skip silently.
+        _ => return Ok(()),
+    };
+
+    let targets = GitBranchPushTargets {
+        branch_updates: vec![(RefNameBuf::from(trunk_name), update)],
+    };
+
+    let mut tx = repo.start_transaction();
+    let stats = git::push_branches(
+        tx.repo_mut(),
+        env.git_settings.to_subprocess_options(),
+        push_remote.as_ref(),
+        &targets,
+        &mut GitSubprocessUi::new(&env.ui),
+    )?;
+
+    print_push_stats(&env.ui, &stats)?;
+    if stats.all_ok() {
+        tx.commit(format!(
+            "push {trunk_name} to {remote}",
+            remote = push_remote.as_str()
+        ))?;
+        writeln!(
+            env.ui.status(),
+            "Fork synced with upstream (pushed {trunk_name} to {})",
+            push_remote.as_str(),
+        )?;
+    } else {
+        writeln!(
+            env.ui.warning_default(),
+            "Failed to push {trunk_name} to {} — fork may be out-of-date",
+            push_remote.as_str(),
+        )?;
+    }
+
+    Ok(())
 }
 
 /// Restack the bookmark graph on top of the trunk branch.

--- a/docs/references/configuration.md
+++ b/docs/references/configuration.md
@@ -15,6 +15,7 @@ For details on how jj resolves its configuration, see the
 | [`spice.output`](#spiceoutput) | `"modern"` \| `"classic"` | `"modern"` | -- |
 | [`spice.auto-accept-changes`](#spiceauto-accept-changes) | `bool` | `false` | `--auto-accept` |
 | [`spice.auto-clean`](#spiceauto-clean) | `bool` | `true` | -- |
+| [`spice.sync-fork`](#spicesync-fork) | `bool` | `false` | `--sync-fork` |
 | [`spice.upstream-remote`](#spiceupstream-remote) | `string` | auto-detected | -- |
 | [`spice.forges.<hostname>.type`](#spiceforgeshostnametype) | `"github"` \| `"gitlab"` | auto-detected | -- |
 
@@ -67,6 +68,29 @@ auto-clean = false
 ```
 
 **Affects:** `stack submit`, `stack sync`.
+
+## `spice.sync-fork`
+
+When `true`, `stack sync` syncs the fork's trunk branch with upstream so the
+fork stays up-to-date on the remote side (not just locally).
+
+On GitHub the sync is performed server-side via the
+`POST /repos/{owner}/{repo}/merge-upstream` API. On GitLab and other forges
+that lack an equivalent endpoint, the freshly-fetched upstream trunk is
+pushed to the fork remote instead.
+
+Only takes effect when fork mode is active (two distinct remotes: push
+remote + upstream remote).
+
+Equivalent to passing `--sync-fork` on the command line. The CLI flag
+takes precedence when used.
+
+```toml
+[spice]
+sync-fork = true
+```
+
+**Affects:** `stack sync`.
 
 ## `spice.upstream-remote`
 

--- a/lib/src/forge.rs
+++ b/lib/src/forge.rs
@@ -176,6 +176,21 @@ pub trait Forge: Send + Sync {
         comment: &'a str,
     ) -> BoxFuture<'a, Result<u64, Box<dyn std::error::Error + Send + Sync>>>;
 
+    /// Sync the fork's branch with the upstream repository on the server side.
+    ///
+    /// Forges that support a native "merge upstream" API (e.g. GitHub) override
+    /// this to fast-forward or merge the fork's branch without a local push.
+    ///
+    /// Returns `Ok(true)` when the sync was performed (or the branch was
+    /// already up-to-date), `Ok(false)` when the forge does not support
+    /// server-side fork syncing (caller should fall back to a local push).
+    fn sync_fork<'a>(
+        &'a self,
+        _branch: &'a str,
+    ) -> BoxFuture<'a, Result<bool, Box<dyn std::error::Error + Send + Sync>>> {
+        Box::pin(async { Ok(false) })
+    }
+
     /// Find change requests matching `source_branch` and return persistable metadata.
     ///
     /// This is a convenience wrapper around [`Forge::find`] that extracts

--- a/lib/src/forge/github.rs
+++ b/lib/src/forge/github.rs
@@ -522,6 +522,39 @@ impl Forge for GitHubForge {
         })
     }
 
+    fn sync_fork<'a>(
+        &'a self,
+        branch: &'a str,
+    ) -> BoxFuture<'a, Result<bool, Box<dyn std::error::Error + Send + Sync>>> {
+        Box::pin(async move {
+            let route = format!("/repos/{}/{}/merge-upstream", self.owner, self.repo);
+            let body = serde_json::json!({ "branch": branch });
+
+            let response = self.client._post(route, Some(&body)).await.map_err(
+                |e| -> Box<dyn std::error::Error + Send + Sync> {
+                    format!("merge-upstream request failed: {e}").into()
+                },
+            )?;
+
+            let status = response.status();
+            match status.as_u16() {
+                200 => Ok(true),
+                // 409 = merge conflict, 422 = cannot sync (not a fork, etc.)
+                409 | 422 => {
+                    let collected = response.into_body().collect().await.map_err(
+                        |e| -> Box<dyn std::error::Error + Send + Sync> {
+                            format!("failed to read merge-upstream response: {e}").into()
+                        },
+                    )?;
+                    let bytes = collected.to_bytes();
+                    let body_str = String::from_utf8_lossy(&bytes);
+                    Err(format!("merge-upstream {status}: {body_str}").into())
+                }
+                other => Err(format!("merge-upstream unexpected status: {other}").into()),
+            }
+        })
+    }
+
     fn get_batch<'a>(&'a self, metas: Vec<&'a ForgeMeta>) -> BoxFuture<'a, Vec<ForgeResult>> {
         Box::pin(async move {
             if metas.is_empty() {
@@ -1496,5 +1529,81 @@ mod tests {
         let forge = mock_forge("http://unused");
         let head = forge.format_head_ref("feat", None);
         assert_eq!(head, format!("{OWNER}:feat"));
+    }
+
+    // -- sync_fork tests --
+
+    #[tokio::test]
+    async fn sync_fork_returns_true_on_success() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(format!("/repos/{OWNER}/{REPO}/merge-upstream")))
+            .and(wiremock::matchers::body_partial_json(
+                json!({"branch": "main"}),
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "message": "Successfully fetched and fast-forwarded from upstream.",
+                "merge_type": "fast-forward",
+                "base_branch": format!("{OWNER}:{REPO}:refs/heads/main")
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let forge = mock_forge(&mock_server.uri());
+        let result = forge.sync_fork("main").await.unwrap();
+        assert!(result);
+    }
+
+    #[tokio::test]
+    async fn sync_fork_returns_true_when_already_up_to_date() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(format!("/repos/{OWNER}/{REPO}/merge-upstream")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "message": "This branch is not behind the upstream.",
+                "merge_type": "none",
+                "base_branch": format!("{OWNER}:{REPO}:refs/heads/main")
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let forge = mock_forge(&mock_server.uri());
+        let result = forge.sync_fork("main").await.unwrap();
+        assert!(result);
+    }
+
+    #[tokio::test]
+    async fn sync_fork_returns_error_on_conflict() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(format!("/repos/{OWNER}/{REPO}/merge-upstream")))
+            .respond_with(
+                ResponseTemplate::new(409).set_body_json(json!({"message": "Merge conflict"})),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let forge = mock_forge(&mock_server.uri());
+        let result = forge.sync_fork("main").await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("409"));
+    }
+
+    #[tokio::test]
+    async fn sync_fork_returns_error_on_unprocessable() {
+        let mock_server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path(format!("/repos/{OWNER}/{REPO}/merge-upstream")))
+            .respond_with(
+                ResponseTemplate::new(422)
+                    .set_body_json(json!({"message": "Repository is not a fork"})),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let forge = mock_forge(&mock_server.uri());
+        let result = forge.sync_fork("main").await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("422"));
     }
 }


### PR DESCRIPTION
In fork mode (origin + upstream remotes), `stack sync --sync-fork` syncs
the fork's default branch with upstream before fetching.

- GitHub: uses `POST /repos/{owner}/{repo}/merge-upstream` API (server-side)
- GitLab / other forges: pushes fetched upstream trunk to the fork remote

Opt-in via `--sync-fork` flag or `spice.sync-fork = true` in jj config.