### PR TITLE
fix: bookmark graph not rendering correctly on diamond and no bookmark

### DIFF
--- a/lib/src/bookmark/graph.rs
+++ b/lib/src/bookmark/graph.rs
@@ -337,17 +337,24 @@ impl<'a> BookmarkGraph<'a> {
         let mut nodes: BTreeMap<String, BookmarkNode> = BTreeMap::new();
         let mut edges: BTreeMap<String, Vec<GraphEdge<String>>> = BTreeMap::new();
         let mut descendants: BTreeMap<String, Vec<GraphEdge<String>>> = BTreeMap::new();
-        let mut visited: HashSet<&CommitId> = HashSet::new();
+
+        // Track which (commit, parent_name) pairs have been processed.
+        // Bookmarked commits only need one visit per commit (the bookmark
+        // name replaces parent_name for children).  Non-bookmarked commits
+        // need one visit per distinct parent_name so that every parent name
+        // propagates through merge points to downstream bookmarks.
+        let mut visited_bookmarked: HashSet<&CommitId> = HashSet::new();
+        let mut visited_passthrough: HashSet<(&CommitId, Option<&str>)> = HashSet::new();
 
         let mut stack: Vec<(&CommitId, Option<&str>)> =
             head_commits.into_iter().map(|c| (c, None)).collect();
 
         while let Some((commit_id, parent_name)) = stack.pop() {
-            let already_visited = !visited.insert(commit_id);
-
             let maybe_bookmarks = bookmarks_per_commit.get(commit_id);
 
             if let Some(bookmarks) = maybe_bookmarks {
+                let first_visit = visited_bookmarked.insert(commit_id);
+
                 for bookmark in bookmarks {
                     let name = bookmark.name().to_string();
 
@@ -379,24 +386,27 @@ impl<'a> BookmarkGraph<'a> {
                             .push(GraphEdge::direct(name.clone()));
                     }
                 }
-            }
 
-            // Only traverse children on first visit to avoid infinite loops.
-            if already_visited {
-                continue;
-            }
-
-            if let Some(graph_node) = commit_index.get(commit_id) {
-                if let Some(bookmarks) = maybe_bookmarks {
-                    // Push children once per bookmark on this commit,
-                    // so each child discovers all parent bookmarks.
+                // Bookmarked commits: only traverse children on first visit.
+                // The bookmark name replaces parent_name for children, so
+                // re-visits would push identical (child, bookmark) pairs.
+                if first_visit && let Some(graph_node) = commit_index.get(commit_id) {
                     for bookmark in bookmarks {
                         for edge in &graph_node.1 {
                             stack.push((&edge.target, Some(bookmark.name())));
                         }
                     }
-                } else {
-                    // No bookmarks on this commit — pass through the parent name.
+                }
+            } else {
+                // Non-bookmarked commit: pass through the parent name.
+                // A merge commit with no bookmark can be reached via
+                // multiple parent paths; each carries a different
+                // parent_name that must reach the downstream bookmarks.
+                // Guard on (commit, parent_name) to avoid redundant work.
+                if !visited_passthrough.insert((commit_id, parent_name)) {
+                    continue;
+                }
+                if let Some(graph_node) = commit_index.get(commit_id) {
                     for edge in &graph_node.1 {
                         stack.push((&edge.target, parent_name));
                     }
@@ -1076,6 +1086,136 @@ mod tests {
         assert_eq!(c_desc, vec!["feat-d"]);
         assert!(!descendants.contains_key("feat-b"));
         assert!(!descendants.contains_key("feat-d"));
+    }
+
+    #[test]
+    fn build_bookmark_graph_diamond_through_unbookmarked_merge() {
+        // Regression: when a merge commit has NO bookmark, the DFS must
+        // still propagate every parent name through it.  Previously only
+        // the first parent_name to reach the merge was passed through.
+        //
+        // Commit graph (roots-first / reversed):
+        //
+        //   library(1)
+        //    / | \
+        //  d(2) s(3) c(4)        ← bookmarked
+        //    \ | /
+        //   merge(5)              ← NO bookmark
+        //     |
+        //   mid(6)                ← NO bookmark
+        //     |
+        //   tip(7)                ← bookmarked "integration-test"
+        //
+        // Expected bookmark edges:
+        //   integration-test -> [deployment, service, cnp]
+        //   deployment       -> [library]
+        //   service          -> [library]
+        //   cnp              -> [library]
+        //   library          -> []
+        let lib = commit_id(1);
+        let d = commit_id(2);
+        let s = commit_id(3);
+        let c = commit_id(4);
+        let merge = commit_id(5);
+        let mid = commit_id(6);
+        let tip = commit_id(7);
+
+        let reversed: Vec<GraphNode<CommitId>> = vec![
+            (
+                lib.clone(),
+                vec![
+                    GraphEdge::direct(d.clone()),
+                    GraphEdge::direct(s.clone()),
+                    GraphEdge::direct(c.clone()),
+                ],
+            ),
+            (d.clone(), vec![GraphEdge::direct(merge.clone())]),
+            (s.clone(), vec![GraphEdge::direct(merge.clone())]),
+            (c.clone(), vec![GraphEdge::direct(merge.clone())]),
+            (merge.clone(), vec![GraphEdge::direct(mid.clone())]),
+            (mid.clone(), vec![GraphEdge::direct(tip.clone())]),
+            (tip.clone(), vec![]),
+        ];
+
+        let bookmarks = bookmark_map(vec![
+            (lib.clone(), vec!["library"]),
+            (d.clone(), vec!["deployment"]),
+            (s.clone(), vec!["service"]),
+            (c.clone(), vec!["cnp"]),
+            (tip.clone(), vec!["integration-test"]),
+        ]);
+
+        let (nodes, edges, descendants) =
+            BookmarkGraph::build_bookmark_graph(&reversed, &bookmarks);
+
+        assert_eq!(nodes.len(), 5);
+
+        // integration-test must have all three feature bookmarks as ascendants.
+        let it_ascendants: HashSet<&str> = nodes["integration-test"]
+            .ascendants()
+            .iter()
+            .map(|s| s.as_str())
+            .collect();
+        assert_eq!(
+            it_ascendants.len(),
+            3,
+            "integration-test should have 3 ascendants, got: {it_ascendants:?}"
+        );
+        assert!(it_ascendants.contains("deployment"));
+        assert!(it_ascendants.contains("service"));
+        assert!(it_ascendants.contains("cnp"));
+
+        // Edges: integration-test -> {deployment, service, cnp}
+        let it_edge_targets: HashSet<&str> = edges["integration-test"]
+            .iter()
+            .map(|e| e.target.as_str())
+            .collect();
+        assert_eq!(it_edge_targets.len(), 3);
+        assert!(it_edge_targets.contains("deployment"));
+        assert!(it_edge_targets.contains("service"));
+        assert!(it_edge_targets.contains("cnp"));
+
+        // Each feature bookmark has library as sole ascendant.
+        for name in &["deployment", "service", "cnp"] {
+            assert_eq!(
+                nodes[*name].ascendants(),
+                &["library"],
+                "{name} should have library as sole ascendant"
+            );
+            let targets: Vec<&str> = edges[*name].iter().map(|e| e.target.as_str()).collect();
+            assert_eq!(
+                targets,
+                vec!["library"],
+                "{name} edge should point to library"
+            );
+        }
+
+        // library is the root (no ascendants, no edges).
+        assert!(nodes["library"].ascendants().is_empty());
+        assert!(edges["library"].is_empty());
+
+        // descendants: library -> {deployment, service, cnp},
+        // each feature -> integration-test
+        let lib_desc: HashSet<&str> = descendants["library"]
+            .iter()
+            .map(|e| e.target.as_str())
+            .collect();
+        assert_eq!(lib_desc.len(), 3);
+        assert!(lib_desc.contains("deployment"));
+        assert!(lib_desc.contains("service"));
+        assert!(lib_desc.contains("cnp"));
+
+        for name in &["deployment", "service", "cnp"] {
+            let desc: Vec<&str> = descendants[*name]
+                .iter()
+                .map(|e| e.target.as_str())
+                .collect();
+            assert_eq!(
+                desc,
+                vec!["integration-test"],
+                "{name} should have integration-test as descendant"
+            );
+        }
     }
 
     // -- Public accessor tests --

--- a/lib/src/bookmark/graph.rs
+++ b/lib/src/bookmark/graph.rs
@@ -450,17 +450,80 @@ impl<'a> BookmarkGraph<'a> {
 
 #[cfg(test)]
 impl<'a> BookmarkGraph<'a> {
-    /// Build a minimal graph for unit-testing code that reads
-    /// `root_bookmarks` and `descendants_for()` (e.g. `Comment::to_string`).
-    pub(crate) fn for_testing(
-        root_bookmarks: Vec<String>,
-        descendants: BTreeMap<String, Vec<GraphEdge<String>>>,
-    ) -> Self {
+    /// Build a fully-wired graph for unit tests.
+    ///
+    /// `node_names` lists bookmarks that exist in the graph but may
+    /// have no edges (e.g. a single standalone bookmark).
+    /// `edges_list` contains `(child, parent)` pairs; both names are
+    /// added to the graph automatically.
+    ///
+    /// Bookmark nodes, head/root bookmarks, and descendants are all
+    /// derived so that [`Self::iter_graph`] works.
+    pub(crate) fn for_testing(node_names: Vec<&str>, edges_list: Vec<(&str, &str)>) -> Self {
+        use jj_lib::op_store::{LocalRemoteRefTarget, RefTarget};
+
+        let mut edges: BTreeMap<String, Vec<GraphEdge<String>>> = BTreeMap::new();
+        let mut descendants: BTreeMap<String, Vec<GraphEdge<String>>> = BTreeMap::new();
+        let mut all_names: HashSet<String> = HashSet::new();
+
+        for name in node_names {
+            all_names.insert(name.to_string());
+        }
+
+        for (child, parent) in &edges_list {
+            all_names.insert(child.to_string());
+            all_names.insert(parent.to_string());
+
+            let edge_list = edges.entry(child.to_string()).or_default();
+            if !edge_list.iter().any(|e| e.target == *parent) {
+                edge_list.push(GraphEdge::direct(parent.to_string()));
+            }
+
+            let desc_list = descendants.entry(parent.to_string()).or_default();
+            if !desc_list.iter().any(|e| e.target == *child) {
+                desc_list.push(GraphEdge::direct(child.to_string()));
+            }
+        }
+
+        // Ensure every name has an edges entry (even if empty).
+        for name in &all_names {
+            edges.entry(name.clone()).or_default();
+        }
+
+        // Build minimal BookmarkNodes with absent ref target.
+        let mut nodes: BTreeMap<String, BookmarkNode> = BTreeMap::new();
+        for name in &all_names {
+            let bookmark = super::Bookmark::new(
+                name.clone(),
+                LocalRemoteRefTarget {
+                    local_target: RefTarget::absent_ref(),
+                    remote_refs: vec![],
+                },
+            );
+            nodes.insert(name.clone(), BookmarkNode::new(bookmark));
+        }
+
+        let head_bookmarks = Self::find_head_bookmarks(&edges);
+
+        // Populate ascendants from edges (child → parent means parent
+        // is an ascendant of child in the bookmark graph's convention).
+        for (name, edge_list) in &edges {
+            for edge in edge_list {
+                if let Some(node) = nodes.get_mut(name)
+                    && !node.ascendants.contains(&edge.target)
+                {
+                    node.ascendants.push(edge.target.clone());
+                }
+            }
+        }
+
+        let root_bookmarks = Self::find_root_bookmarks(&nodes);
+
         Self {
-            nodes: BTreeMap::new(),
-            edges: BTreeMap::new(),
+            nodes,
+            edges,
             descendants,
-            head_bookmarks: Vec::new(),
+            head_bookmarks,
             root_bookmarks,
         }
     }

--- a/lib/src/comments.rs
+++ b/lib/src/comments.rs
@@ -35,10 +35,6 @@ pub enum CommentError {
     NoChangeRequestFound(String),
     #[error("No forge metadata found for bookmark {0}")]
     NoForgeMetadataFound(String),
-    #[error("No base branch found)")]
-    NoBaseBranchFound,
-    #[error("No target branch found)")]
-    NoTargetBranchFound,
 }
 
 /// Renders a stack-trace comment for a change request.
@@ -91,8 +87,7 @@ impl<'a> Comment<'a> {
     /// vertical graph with Unicode box-drawing characters, bookmark nodes
     /// rendered top-to-bottom (leaf first, root last, trunk at bottom).
     pub fn to_string(&self) -> Result<String, CommentError> {
-        let ascendant_to_crs = self.build_ascendant_map()?;
-        let ordered = self.collect_ordered_nodes(&ascendant_to_crs)?;
+        let ordered = self.collect_ordered_nodes()?;
 
         let mut output = String::from("This change belongs to the following stack:\n<pre>\n");
 
@@ -135,65 +130,36 @@ impl<'a> Comment<'a> {
     }
 
     /// Collect nodes in reversed topological order (leaf-first, root-last).
-    fn collect_ordered_nodes(
-        &self,
-        ascendant_to_crs: &BTreeMap<String, Vec<&ForgeMeta>>,
-    ) -> Result<Vec<CommentNode>, CommentError> {
-        let mut nodes = Vec::new();
-        let mut visited = Vec::new();
-
-        let mut stack: Vec<&ForgeMeta> = self
+    ///
+    /// Delegates to [`BookmarkGraph::iter_graph`] for the topological
+    /// ordering, then reverses so leaves appear first (matching the
+    /// visual layout where the tip of the stack is at the top).
+    fn collect_ordered_nodes(&self) -> Result<Vec<CommentNode>, CommentError> {
+        let topo_names: Vec<&str> = self
             .graph
-            .root_bookmarks
-            .iter()
-            .map(|b| {
-                self.change_requests
-                    .get(b)
-                    .ok_or_else(|| CommentError::NoChangeRequestFound(b.clone()))
+            .iter_graph()
+            .map_err(|_| CommentError::NoChangeRequestFound("(cycle)".into()))?
+            .map(|node| node.name())
+            .collect();
+
+        let nodes: Vec<CommentNode> = topo_names
+            .into_iter()
+            .rev()
+            .map(|name| {
+                let meta = self
+                    .change_requests
+                    .get(name)
+                    .ok_or_else(|| CommentError::NoChangeRequestFound(name.to_string()))?;
+                let (cr_label, cr_url) = Self::extract_cr_info(meta);
+                Ok(CommentNode {
+                    source_branch: name.to_string(),
+                    cr_label,
+                    cr_url,
+                })
             })
-            .collect::<Result<Vec<_>, _>>()?;
+            .collect::<Result<_, _>>()?;
 
-        while let Some(meta) = stack.pop() {
-            if visited.contains(&meta) {
-                continue;
-            }
-            visited.push(meta);
-
-            let source_branch = meta
-                .source_branch()
-                .ok_or(CommentError::NoTargetBranchFound)?;
-
-            let (cr_label, cr_url) = Self::extract_cr_info(meta);
-
-            nodes.push(CommentNode {
-                source_branch: source_branch.to_string(),
-                cr_label,
-                cr_url,
-            });
-
-            for next in ascendant_to_crs.get(source_branch).unwrap_or(&vec![]) {
-                stack.push(next);
-            }
-        }
-
-        // Reverse: DFS from roots produces root-first, we want leaf-first.
-        nodes.reverse();
         Ok(nodes)
-    }
-
-    /// Build a map from ascendant bookmark name to its descendant ForgeMeta entries.
-    fn build_ascendant_map(&self) -> Result<BTreeMap<String, Vec<&ForgeMeta>>, CommentError> {
-        let mut map: BTreeMap<String, Vec<&ForgeMeta>> = BTreeMap::new();
-        for meta in self.change_requests.by_bookmark.values() {
-            let target_branch = meta
-                .target_branch()
-                .ok_or(CommentError::NoBaseBranchFound)?;
-
-            if self.change_requests.get(target_branch).is_some() {
-                map.entry(target_branch.to_string()).or_default().push(meta);
-            }
-        }
-        Ok(map)
     }
 
     /// Format a CR reference as a clickable `<a>` tag.
@@ -381,7 +347,7 @@ mod tests {
     #[test]
     fn single_bookmark_graph() {
         let bookmark = make_bookmark("feat-a");
-        let graph = BookmarkGraph::for_testing(vec!["feat-a".into()], BTreeMap::new());
+        let graph = BookmarkGraph::for_testing(vec!["feat-a"], vec![]);
         let crs = make_change_requests(vec![("feat-a", 1, "main")]);
 
         let comment = Comment::new(&bookmark, &graph, &crs).with_trunk("main");
@@ -400,7 +366,7 @@ mod tests {
     #[test]
     fn linear_stack_ordering() {
         let current = make_bookmark("mid");
-        let graph = BookmarkGraph::for_testing(vec!["root".into()], BTreeMap::new());
+        let graph = BookmarkGraph::for_testing(vec![], vec![("leaf", "mid"), ("mid", "root")]);
         let crs = make_change_requests(vec![
             ("root", 10, "main"),
             ("mid", 11, "root"),
@@ -427,7 +393,7 @@ mod tests {
     #[test]
     fn current_bookmark_is_root() {
         let current = make_bookmark("root");
-        let graph = BookmarkGraph::for_testing(vec!["root".into()], BTreeMap::new());
+        let graph = BookmarkGraph::for_testing(vec![], vec![("child", "root")]);
         let crs = make_change_requests(vec![("root", 1, "main"), ("child", 2, "root")]);
 
         let comment = Comment::new(&current, &graph, &crs).with_trunk("main");
@@ -445,7 +411,7 @@ mod tests {
     #[test]
     fn live_data_shows_status_and_title() {
         let current = make_bookmark("feat-a");
-        let graph = BookmarkGraph::for_testing(vec!["feat-a".into()], BTreeMap::new());
+        let graph = BookmarkGraph::for_testing(vec!["feat-a"], vec![]);
         let crs = make_change_requests(vec![("feat-a", 42, "main")]);
         let live = make_live_data(vec![(
             "feat-a",
@@ -467,7 +433,7 @@ mod tests {
     #[test]
     fn live_data_draft_and_merged() {
         let current = make_bookmark("feat-b");
-        let graph = BookmarkGraph::for_testing(vec!["feat-a".into()], BTreeMap::new());
+        let graph = BookmarkGraph::for_testing(vec![], vec![("feat-b", "feat-a")]);
         let crs = make_change_requests(vec![("feat-a", 10, "main"), ("feat-b", 11, "feat-a")]);
         let live = make_live_data(vec![
             (
@@ -494,7 +460,7 @@ mod tests {
     #[test]
     fn live_data_closed() {
         let current = make_bookmark("feat");
-        let graph = BookmarkGraph::for_testing(vec!["feat".into()], BTreeMap::new());
+        let graph = BookmarkGraph::for_testing(vec!["feat"], vec![]);
         let crs = make_change_requests(vec![("feat", 5, "main")]);
         let live = make_live_data(vec![(
             "feat",
@@ -514,7 +480,7 @@ mod tests {
     #[test]
     fn without_trunk_omits_diamond() {
         let bookmark = make_bookmark("feat-a");
-        let graph = BookmarkGraph::for_testing(vec!["feat-a".into()], BTreeMap::new());
+        let graph = BookmarkGraph::for_testing(vec!["feat-a"], vec![]);
         let crs = make_change_requests(vec![("feat-a", 1, "main")]);
 
         let comment = Comment::new(&bookmark, &graph, &crs);
@@ -527,7 +493,7 @@ mod tests {
     #[test]
     fn connector_lines_between_nodes() {
         let bookmark = make_bookmark("root");
-        let graph = BookmarkGraph::for_testing(vec!["root".into()], BTreeMap::new());
+        let graph = BookmarkGraph::for_testing(vec![], vec![("child", "root")]);
         let crs = make_change_requests(vec![("root", 1, "main"), ("child", 2, "root")]);
 
         let comment = Comment::new(&bookmark, &graph, &crs).with_trunk("main");
@@ -539,7 +505,8 @@ mod tests {
     #[test]
     fn forking_stack_both_children_above_root() {
         let current = make_bookmark("root");
-        let graph = BookmarkGraph::for_testing(vec!["root".into()], BTreeMap::new());
+        let graph =
+            BookmarkGraph::for_testing(vec![], vec![("child-a", "root"), ("child-b", "root")]);
         let crs = make_change_requests(vec![
             ("root", 1, "main"),
             ("child-a", 2, "root"),
@@ -561,12 +528,67 @@ mod tests {
         assert!(child_b_pos < root_pos, "child-b should be above root");
     }
 
+    #[test]
+    fn diamond_graph_includes_all_branches() {
+        // Diamond: library -> {deployment, service, cnp} -> integration-test
+        // All branches must appear in the comment regardless of the
+        // ForgeMeta target_branch (which can only point to one parent).
+        let current = make_bookmark("integration-test");
+        let graph = BookmarkGraph::for_testing(
+            vec![],
+            vec![
+                ("integration-test", "deployment"),
+                ("integration-test", "service"),
+                ("integration-test", "cnp"),
+                ("deployment", "library"),
+                ("service", "library"),
+                ("cnp", "library"),
+            ],
+        );
+        let crs = make_change_requests(vec![
+            ("library", 10, "main"),
+            ("deployment", 11, "library"),
+            ("service", 12, "library"),
+            ("cnp", 13, "library"),
+            // target_branch is only "deployment" — but the graph knows all 3 parents.
+            ("integration-test", 14, "deployment"),
+        ]);
+
+        let comment = Comment::new(&current, &graph, &crs).with_trunk("main");
+        let output = comment.to_string().unwrap();
+
+        // All five bookmarks must appear.
+        assert!(output.contains("library #10"));
+        assert!(output.contains("deployment #11"));
+        assert!(output.contains("service #12"));
+        assert!(output.contains("cnp #13"));
+        assert!(output.contains("integration-test #14"));
+
+        // integration-test (leaf) should be above all others.
+        let it_pos = output.find("integration-test").unwrap();
+        let lib_pos = output.find("library #10").unwrap();
+        assert!(it_pos < lib_pos, "integration-test should be above library");
+
+        // library (root) should be closest to trunk.
+        let trunk_pos = output.find("◆  main").unwrap();
+        assert!(lib_pos < trunk_pos, "library should be above trunk");
+
+        // All three middle branches should be between integration-test and library.
+        for name in &["deployment", "service", "cnp"] {
+            let pos = output.find(&format!("{name} #")).unwrap();
+            assert!(
+                it_pos < pos && pos < lib_pos,
+                "{name} should be between integration-test and library"
+            );
+        }
+    }
+
     // -- GitLab tests --
 
     #[test]
     fn single_gitlab_mr_graph() {
         let bookmark = make_bookmark("feat-a");
-        let graph = BookmarkGraph::for_testing(vec!["feat-a".into()], BTreeMap::new());
+        let graph = BookmarkGraph::for_testing(vec!["feat-a"], vec![]);
         let crs = make_gitlab_change_requests(vec![("feat-a", 1, "main")]);
 
         let comment = Comment::new(&bookmark, &graph, &crs).with_trunk("main");
@@ -585,7 +607,7 @@ mod tests {
     #[test]
     fn linear_gitlab_stack_ordering() {
         let current = make_bookmark("mid");
-        let graph = BookmarkGraph::for_testing(vec!["root".into()], BTreeMap::new());
+        let graph = BookmarkGraph::for_testing(vec![], vec![("leaf", "mid"), ("mid", "root")]);
         let crs = make_gitlab_change_requests(vec![
             ("root", 10, "main"),
             ("mid", 11, "root"),
@@ -611,7 +633,7 @@ mod tests {
     #[test]
     fn gitlab_live_data_produces_clickable_links() {
         let current = make_bookmark("feat-a");
-        let graph = BookmarkGraph::for_testing(vec!["feat-a".into()], BTreeMap::new());
+        let graph = BookmarkGraph::for_testing(vec!["feat-a"], vec![]);
         let crs = make_gitlab_change_requests(vec![("feat-a", 42, "main")]);
         let live = make_live_data(vec![(
             "feat-a",
@@ -636,7 +658,7 @@ mod tests {
     #[test]
     fn html_escapes_special_chars() {
         let bookmark = make_bookmark("feat<xss>");
-        let graph = BookmarkGraph::for_testing(vec!["feat<xss>".into()], BTreeMap::new());
+        let graph = BookmarkGraph::for_testing(vec!["feat<xss>"], vec![]);
 
         let mut crs = ChangeRequests::default();
         crs.set(
@@ -666,7 +688,7 @@ mod tests {
     #[test]
     fn missing_change_request_for_root_returns_error() {
         let bookmark = make_bookmark("feat-a");
-        let graph = BookmarkGraph::for_testing(vec!["feat-a".into()], BTreeMap::new());
+        let graph = BookmarkGraph::for_testing(vec!["feat-a"], vec![]);
         let crs = ChangeRequests::default();
 
         let comment = Comment::new(&bookmark, &graph, &crs);
@@ -676,17 +698,20 @@ mod tests {
     }
 
     #[test]
-    fn missing_forge_variant_returns_no_base_branch() {
+    fn missing_forge_variant_renders_without_cr_label() {
         let bookmark = make_bookmark("feat-a");
-        let graph = BookmarkGraph::for_testing(vec!["feat-a".into()], BTreeMap::new());
+        let graph = BookmarkGraph::for_testing(vec!["feat-a"], vec![]);
 
         let mut crs = ChangeRequests::default();
         crs.set("feat-a".to_string(), ForgeMeta { forge: None });
 
         let comment = Comment::new(&bookmark, &graph, &crs);
-        let err = comment.to_string().unwrap_err();
+        let output = comment.to_string().unwrap();
 
-        assert!(matches!(err, CommentError::NoBaseBranchFound));
+        // Node renders with bookmark name but no CR label or link.
+        assert!(output.contains("feat-a"));
+        let pre_block = output.split("</pre>").next().unwrap();
+        assert!(!pre_block.contains("<a href="));
     }
 
     // -- Footer test --
@@ -694,7 +719,7 @@ mod tests {
     #[test]
     fn includes_jj_spice_footer() {
         let bookmark = make_bookmark("feat");
-        let graph = BookmarkGraph::for_testing(vec!["feat".into()], BTreeMap::new());
+        let graph = BookmarkGraph::for_testing(vec!["feat"], vec![]);
         let crs = make_change_requests(vec![("feat", 42, "main")]);
 
         let comment = Comment::new(&bookmark, &graph, &crs);


### PR DESCRIPTION
Comment rendering in `comments.rs` reconstructed the stack structure
from `ForgeMeta.target_branch()` links instead of using the actual
`BookmarkGraph` edges.  Since a GitHub PR has exactly one base branch,
this produced a tree that cannot represent diamonds or forks.

Switch to using the graph's `iter_graph()` for traversal order and
`edges_for()` / `descendants_for()` for the actual topology.