### PR TITLE
fix: update working copy after commit-rewriting transactions

### DIFF
--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -93,7 +93,7 @@ pub(crate) fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
 
                         stack_submit::run(
                             &submit_args,
-                            &env,
+                            &mut env,
                             forge.as_ref(),
                             source_repo.as_deref(),
                             &trunk,
@@ -109,7 +109,7 @@ pub(crate) fn run(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                         .map_err(|e| format!("failed to resolve @: {e}"))?;
                     rt.block_on(stack_sync::run(
                         &sync_args,
-                        &env,
+                        &mut env,
                         &trunk,
                         &head,
                         &trunk_name,

--- a/cli/src/commands/env.rs
+++ b/cli/src/commands/env.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::io::Write;
 use std::sync::Arc;
 
 use jj_cli::cli_util::{GlobalArgs, RevisionArg, find_workspace_dir};
@@ -21,6 +22,7 @@ use jj_lib::revset::{
     RevsetParseContext, RevsetWorkspaceContext,
 };
 use jj_lib::settings::UserSettings;
+use jj_lib::transaction::Transaction;
 use jj_lib::workspace::{
     DefaultWorkspaceLoaderFactory, Workspace, WorkspaceLoaderFactory,
     default_working_copy_factories,
@@ -332,6 +334,78 @@ impl SpiceEnv {
         );
 
         Ok(evaluator.resolve()?)
+    }
+
+    /// Commit a transaction and update the on-disk working copy to match.
+    ///
+    /// After transactions that rewrite commits (rebase, sign, etc.) the
+    /// operation log records the new state but the working tree on disk still
+    /// reflects the pre-rewrite commit.  This helper bridges the gap:
+    ///
+    /// 1. Resolves the old and new working-copy commits from the transaction.
+    /// 2. For colocated repos, resets the git HEAD and exports refs.
+    /// 3. Commits the transaction to the operation log.
+    /// 4. Checks out the (potentially rewritten) working-copy commit on disk.
+    ///
+    /// Returns the committed `ReadonlyRepo` snapshot so callers can continue
+    /// operating against the up-to-date state.
+    pub(crate) fn commit_and_update_working_copy(
+        &mut self,
+        mut tx: Transaction,
+        description: impl Into<String>,
+    ) -> Result<Arc<ReadonlyRepo>, Box<dyn std::error::Error>> {
+        let ws_name = self.workspace.workspace_name().to_owned();
+
+        // Resolve old working-copy commit from the base repo (before the tx).
+        let old_wc_commit = tx
+            .base_repo()
+            .view()
+            .get_wc_commit_id(&ws_name)
+            .map(|id| tx.base_repo().store().get_commit(id))
+            .transpose()?;
+
+        // Resolve new working-copy commit from the mutated repo (after rewrites).
+        let new_wc_commit = tx
+            .repo()
+            .view()
+            .get_wc_commit_id(&ws_name)
+            .map(|id| tx.repo().store().get_commit(id))
+            .transpose()?;
+
+        // Colocated git repo: reset HEAD and export refs before committing.
+        if jj_cli::git_util::is_colocated_git_workspace(&self.workspace, tx.base_repo()) {
+            if let Some(wc_commit) = &new_wc_commit {
+                // Errors updating HEAD are non-fatal — the actual state will
+                // be imported on the next snapshot.
+                if let Err(e) = jj_lib::git::reset_head(tx.repo_mut(), wc_commit) {
+                    writeln!(self.ui.warning_default(), "{e}")?;
+                }
+            }
+            let stats = jj_lib::git::export_refs(tx.repo_mut())?;
+            jj_cli::git_util::print_git_export_stats(&self.ui, &stats)?;
+        }
+
+        // Commit the transaction to the operation log.
+        let repo = tx.commit(description)?;
+
+        // Check out the (possibly rewritten) working-copy tree on disk.
+        if let Some(new_commit) = &new_wc_commit {
+            let old_tree = old_wc_commit.as_ref().map(|c| c.tree());
+            let stats =
+                self.workspace
+                    .check_out(repo.op_id().clone(), old_tree.as_ref(), new_commit)?;
+            if stats.added_files > 0 || stats.updated_files > 0 || stats.removed_files > 0 {
+                writeln!(
+                    self.ui.status(),
+                    "Added {} files, modified {} files, removed {} files",
+                    stats.added_files,
+                    stats.updated_files,
+                    stats.removed_files,
+                )?;
+            }
+        }
+
+        Ok(repo)
     }
 }
 

--- a/cli/src/commands/stack_submit.rs
+++ b/cli/src/commands/stack_submit.rs
@@ -60,18 +60,14 @@ enum ResolvedBaseBookmark {
 /// forge-specific format.
 pub async fn run(
     args: &SubmitArgs,
-    env: &SpiceEnv,
+    env: &mut SpiceEnv,
     forge: &dyn Forge,
     source_repo: Option<&str>,
     trunk: &CommitId,
     head: &CommitId,
     trunk_name: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let store = &env.store;
-    let cr_store = ChangeRequestStore::new(store);
-    let graph = BookmarkGraph::build_active_graph(env.repo.as_ref(), trunk, head)?;
     let text_editor = TextEditor::from_settings(&env.settings)?;
-    let mut state = cr_store.load()?;
 
     let auto_accept =
         if let Ok(auto_accept) = env.config().get::<bool>(["spice", "auto-accept-changes"]) {
@@ -93,13 +89,22 @@ pub async fn run(
     // transaction first.  The returned repo (or `env.repo` if nothing was
     // tracked) is then used to classify every bookmark's push action and to
     // validate commits.
-    let (repo_for_push, push_entries, cr_metas) =
-        collect_push_data(env, &graph, auto_accept, args.auto_track_bookmarks)?;
+    let (repo_for_push, push_entries, cr_metas) = {
+        let graph = BookmarkGraph::build_active_graph(env.repo.as_ref(), trunk, head)?;
+        collect_push_data(env, &graph, auto_accept, args.auto_track_bookmarks)?
+    };
 
     // ── Batch sign + push (single transaction) ──
     if !push_entries.is_empty() {
         batch_push(env, &repo_for_push, trunk, push_entries)?;
     }
+
+    // Load the CR store and rebuild the graph after batch_push so the mutable
+    // borrow of `env` used by `commit_and_update_working_copy` doesn't
+    // conflict with the store/graph references.
+    let cr_store = ChangeRequestStore::new(&env.store);
+    let mut state = cr_store.load()?;
+    let graph = BookmarkGraph::build_active_graph(env.repo.as_ref(), trunk, head)?;
 
     // ── Pass 2: Create / retarget change requests ──
     for meta in &cr_metas {
@@ -469,7 +474,7 @@ fn remap_push_targets(
 /// all signing, rebasing, and pushing happen within one transaction that is
 /// committed at the end so jj's repo state stays consistent with the remote.
 fn batch_push(
-    env: &SpiceEnv,
+    env: &mut SpiceEnv,
     repo: &Arc<ReadonlyRepo>,
     trunk: &CommitId,
     entries: Vec<BookmarkPushEntry>,
@@ -562,9 +567,10 @@ fn batch_push(
 
     print_push_stats(&env.ui, &push_stats)?;
 
-    // 6. Commit the transaction so jj's local state matches the remote.
+    // 6. Commit the transaction and update the working copy so jj's local
+    //    state (both operation log and on-disk tree) matches the remote.
     if push_stats.all_ok() {
-        tx.commit("push stack bookmarks".to_string())?;
+        env.commit_and_update_working_copy(tx, "push stack bookmarks")?;
         for entry in &entries {
             writeln!(
                 env.ui.stdout_formatter(),

--- a/cli/src/commands/stack_sync.rs
+++ b/cli/src/commands/stack_sync.rs
@@ -51,7 +51,7 @@ enum BookmarkSyncError {
 /// The choice is persisted to the jj repo config so future runs skip the prompt.
 pub async fn run(
     args: &SyncArgs,
-    env: &SpiceEnv,
+    env: &mut SpiceEnv,
     trunk: &CommitId,
     head: &CommitId,
     trunk_name: &str,
@@ -80,16 +80,24 @@ pub async fn run(
 
     // Build the bookmark graph. If the `--restack` flag is specified, rebase the
     // stack onto trunk first, then build the graph from the updated repo state.
-    let active_repo = if args.restack {
+    let (active_repo, head) = if args.restack {
         // Build a temporary graph to discover root bookmarks, then rebase.
         let initial_graph =
             BookmarkGraph::build_active_graph(repo_after_fetch.as_ref(), &trunk, head)?;
         let root_bookmarks = initial_graph.root_bookmarks.clone();
-        restack_graph(env, &repo_after_fetch, &root_bookmarks, &trunk)?
+        let repo = restack_graph(env, &repo_after_fetch, &root_bookmarks, &trunk)?;
+        // Re-resolve @ from the rebased repo — the old commit ID is stale.
+        let ws_name = env.workspace.workspace_name();
+        let new_head = repo
+            .view()
+            .get_wc_commit_id(ws_name)
+            .cloned()
+            .unwrap_or_else(|| head.clone());
+        (repo, new_head)
     } else {
-        repo_after_fetch
+        (repo_after_fetch, head.clone())
     };
-    let graph = BookmarkGraph::build_active_graph(active_repo.as_ref(), &trunk, head)?;
+    let graph = BookmarkGraph::build_active_graph(active_repo.as_ref(), &trunk, &head)?;
 
     let spice_store = SpiceStore::init_at(env.workspace.repo_path())?;
     let cr_store = ChangeRequestStore::new(&spice_store);
@@ -343,7 +351,7 @@ fn fetch_trunk(
 /// `env.repo`) so that the rebase sees the freshly-fetched trunk position.
 /// Returns the committed repo for downstream graph construction.
 fn restack_graph(
-    env: &SpiceEnv,
+    env: &mut SpiceEnv,
     repo: &Arc<ReadonlyRepo>,
     root_bookmarks: &[String],
     trunk: &CommitId,
@@ -382,7 +390,7 @@ fn restack_graph(
     tx.repo_mut().rebase_descendants()?;
 
     print_move_commits_stats(&env.ui, &stats)?;
-    Ok(tx.commit("restack bookmarks on trunk")?)
+    env.commit_and_update_working_copy(tx, "restack bookmarks on trunk")
 }
 
 /// Print details about the provided [`MoveCommitsStats`].


### PR DESCRIPTION
Transactions that rewrite commits (restack in `stack sync`, sign+push
in `stack submit`) left the on-disk working copy stale because
`tx.commit()` only persists to the operation log without checking out
the rewritten `@`.

Add a common `commit_and_update_working_copy` helper that commits the
transaction and then updates the on-disk working copy to match the
rewritten state. Use it in both `restack_graph` and `batch_push`.

Also re-resolve `head` (`@`) after restack so downstream graph
construction sees the correct (rewritten) commit ID.