### PR TITLE
fix: exclude remote-only bookmarks from bookmark graph, fix #89

### DIFF
--- a/lib/src/bookmark.rs
+++ b/lib/src/bookmark.rs
@@ -326,6 +326,36 @@ mod tests {
         assert_eq!(resolve_commit_id(&absent_target()), None);
     }
 
+    // -- local_target predicate tests --
+    // build_bookmark_commit_map() filters on local_target.as_normal().is_some()
+    // to exclude remote-only bookmarks from the graph. These tests guard that
+    // invariant.
+
+    #[test]
+    fn remote_only_bookmark_has_no_local_target() {
+        let id = commit_id(1);
+        let remote = make_remote_ref_at(&id, false);
+        let target = LocalRemoteRefTarget {
+            local_target: RefTarget::absent_ref(),
+            remote_refs: vec![(RemoteName::new("origin"), &remote)],
+        };
+        // Remote-only: resolve_commit_id succeeds (via fallback) but
+        // local_target is absent — graph should exclude this.
+        assert!(target.local_target.as_normal().is_none());
+        assert!(resolve_commit_id(&target).is_some());
+    }
+
+    #[test]
+    fn local_bookmark_has_local_target() {
+        let id = commit_id(2);
+        let local = RefTarget::normal(id.clone());
+        let target = LocalRemoteRefTarget {
+            local_target: &local,
+            remote_refs: vec![],
+        };
+        assert!(target.local_target.as_normal().is_some());
+    }
+
     #[test]
     fn resolve_commit_id_skips_absent_remote_refs() {
         let id = commit_id(5);

--- a/lib/src/bookmark/graph.rs
+++ b/lib/src/bookmark/graph.rs
@@ -299,10 +299,8 @@ impl<'a> BookmarkGraph<'a> {
     ) -> HashMap<CommitId, Vec<Arc<Bookmark<'a>>>> {
         repo.view()
             .bookmarks()
+            .filter(|(_, ref_target)| ref_target.local_target.as_normal().is_some())
             .filter_map(|(ref_name, ref_target)| {
-                // Resolve via local target first, falling back to remote refs.
-                // This handles bookmarks that only exist as remote-tracking
-                // refs (e.g. main@origin with no local main).
                 let commit_id = resolve_commit_id(&ref_target)?;
                 Some((
                     commit_id.to_owned(),


### PR DESCRIPTION
`build_bookmark_commit_map()` included all bookmarks from
`repo.view().bookmarks()`, which returns both local and remote-only
refs. Combined with `resolve_commit_id()`'s fallback to remote refs,
this caused remote-only branches (from other contributors) to appear
in `stack log` output.

### Changes

- Added `.filter(|(_, ref_target)| ref_target.local_target.as_normal().is_some())`
  to `build_bookmark_commit_map()` in `lib/src/bookmark/graph.rs`

This matches the documented behavior of `all_local()`:
> Remote-only bookmarks (from other contributors) are excluded.

Fixes https://github.com/alejoborbo/jj-spice/issues/89

---

test: add tests for local_target predicate used by bookmark graph filter

Added two tests in `lib/src/bookmark.rs` that document the invariant
`build_bookmark_commit_map()` relies on:

- `remote_only_bookmark_has_no_local_target` — verifies that a
  remote-only bookmark has no local target (so the graph filter
  excludes it), even though `resolve_commit_id()` would resolve it
- `local_bookmark_has_local_target` — verifies that a local bookmark
  passes the filter